### PR TITLE
[FEAT] 카페 리스트 조회 시 태그 함께 반환하도록 수정

### DIFF
--- a/src/main/kotlin/com/coffee/api/cafe/application/CafeService.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/CafeService.kt
@@ -13,6 +13,6 @@ class CafeService(
 
     override fun execute(input: FindCafe.Query): FindCafe.Result {
         val findAllCafesById = cafeRepository.findAllCafesById(input.lastCafeId, 5)
-        return FindCafe.Result(findAllCafesById.cafes, findAllCafesById.hasNext)
+        return FindCafe.Result(findAllCafesById.cafeInfoWithTags, findAllCafesById.hasNext)
     }
 }

--- a/src/main/kotlin/com/coffee/api/cafe/application/usecase/FindCafe.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/usecase/FindCafe.kt
@@ -1,6 +1,6 @@
 package com.coffee.api.cafe.application.usecase
 
-import com.coffee.api.cafe.domain.Cafe
+import com.coffee.api.cafe.domain.CafeInfoWithTags
 import com.coffee.api.common.domain.QueryUseCase
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
@@ -12,7 +12,7 @@ interface FindCafe : QueryUseCase<FindCafe.Query, FindCafe.Result> {
 
     @Schema(name = "Find All Cafe", description = "모든 카페 리스트")
     data class Result(
-        val result: List<Cafe>,
+        val result: List<CafeInfoWithTags>,
         val hasNext: Boolean,
     ) : QueryUseCase.Result
 }

--- a/src/main/kotlin/com/coffee/api/cafe/domain/CafeInfoWithTags.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/domain/CafeInfoWithTags.kt
@@ -1,0 +1,25 @@
+package com.coffee.api.cafe.domain
+
+class CafeInfoWithTags(
+    val cafeId: Cafe.Id,
+    val name: String,
+    val nearestStation: String,
+    val location: String,
+    val price: Int,
+    val previewImages: String?,
+    val tags: List<Tag>,
+) {
+    companion object {
+        fun of(cafe: Cafe, tags: List<Tag>): CafeInfoWithTags {
+            return CafeInfoWithTags(
+                cafeId = cafe.id,
+                name = cafe.name,
+                nearestStation = cafe.nearestStation,
+                location = cafe.location,
+                price = cafe.price,
+                previewImages = cafe.previewImages,
+                tags = tags
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/coffee/api/cafe/domain/CafePage.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/domain/CafePage.kt
@@ -3,13 +3,13 @@ package com.coffee.api.cafe.domain
 import org.springframework.data.domain.Slice
 
 class CafePage(
-    val cafes: List<Cafe>,
+    val cafeInfoWithTags: List<CafeInfoWithTags>,
     val hasNext: Boolean,
 ) {
     companion object {
-        fun from(slice: Slice<Cafe>): CafePage {
+        fun from(slice: Slice<CafeInfoWithTags>): CafePage {
             return CafePage(
-                cafes = slice.content,
+                cafeInfoWithTags = slice.content,
                 hasNext = slice.hasNext(),
             )
         }


### PR DESCRIPTION
## 관련 이슈
close #20 

## 주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.
카페 리스트 조회 시 태그 정보 함께 리턴

## 기타
> 고려해야 하는 내용을 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 카페 검색 결과에 태그 정보 추가
	- 카페 정보에 연관된 태그를 포함하여 표시

- **개선 사항**
	- 카페 데이터 구조를 확장하여 더 풍부한 정보 제공
	- 카페 목록 조회 시 태그 정보 함께 반환

<!-- end of auto-generated comment: release notes by coderabbit.ai -->