### PR TITLE
[FEATURE] 카페 추천 그룹 조회 API

### DIFF
--- a/src/main/kotlin/com/coffee/api/cafe/application/CafeRecommendGroupService.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/CafeRecommendGroupService.kt
@@ -18,7 +18,7 @@ class CafeRecommendGroupService(
                 name = it.group.title,
                 cafes = it.cafes.map { cafe ->
                     FindRecommendCafe.SimpleCafe(
-                        id = cafe.id.toString(),
+                        id = cafe.id.value.toString(),
                         mainImage = cafe.mainImages?.firstOrNull() ?: "",
                         name = cafe.name,
                         nearestStation = cafe.nearestStation,

--- a/src/main/kotlin/com/coffee/api/cafe/application/CafeRecommendGroupService.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/CafeRecommendGroupService.kt
@@ -1,0 +1,35 @@
+package com.coffee.api.cafe.application
+
+import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
+import com.coffee.api.cafe.application.port.outbound.CafeRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class CafeRecommendGroupService(
+    private val cafeRepository: CafeRepository,
+) : FindRecommendCafe {
+    override fun execute(input: FindRecommendCafe.Query): FindRecommendCafe.Result {
+        val result = cafeRepository.findAllCafesInVisibleGroups(input.lastCafeId, input.limit)
+
+        val groups = result.content.map {
+            FindRecommendCafe.CafeRecommendGroup(
+                name = it.group.title,
+                cafes = it.cafes.map { cafe ->
+                    FindRecommendCafe.SimpleCafe(
+                        id = cafe.id.toString(),
+                        mainImage = cafe.mainImages?.firstOrNull() ?: "",
+                        name = cafe.name,
+                        nearestStation = cafe.nearestStation,
+                    )
+                },
+            )
+        }
+
+        return FindRecommendCafe.Result(
+            groups = groups,
+            hasNext = result.hasNext,
+        )
+    }
+}

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindRecommendCafe.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindRecommendCafe.kt
@@ -1,0 +1,29 @@
+package com.coffee.api.cafe.application.port.inbound
+
+import com.coffee.api.common.domain.UseCase
+import java.util.*
+
+interface FindRecommendCafe : UseCase<FindRecommendCafe.Query, FindRecommendCafe.Result> {
+
+    data class Query(
+        val lastCafeId: UUID?,
+        val limit: Int,
+    )
+
+    data class Result(
+        val groups: List<CafeRecommendGroup>,
+        val hasNext: Boolean,
+    )
+
+    data class CafeRecommendGroup(
+        val name: String,
+        val cafes: List<SimpleCafe>,
+    )
+
+    data class SimpleCafe(
+        val id: String,
+        val mainImage: String,
+        val name: String,
+        val nearestStation: String,
+    )
+}

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/CafeRepository.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/CafeRepository.kt
@@ -1,12 +1,14 @@
 package com.coffee.api.cafe.application.port.outbound
 
 import com.coffee.api.cafe.application.model.CafeDetails
-import com.coffee.api.cafe.domain.Cafe
 import com.coffee.api.cafe.application.model.CafePage
+import com.coffee.api.cafe.application.port.outbound.model.CafeInfoWithRecommendGroups
+import com.coffee.api.cafe.domain.Cafe
 import java.util.UUID
 
 interface CafeRepository {
     fun findAll(): List<Cafe>
     fun findAllCafesById(lastCafeId: UUID?, limit: Int): CafePage
     fun findByCafeId(cafeId: UUID?): CafeDetails
+    fun findAllCafesInVisibleGroups(lastCafeId: UUID?, limit: Int): CafeInfoWithRecommendGroups
 }

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/model/CafeInfoWithRecommendGroups.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/model/CafeInfoWithRecommendGroups.kt
@@ -1,0 +1,16 @@
+package com.coffee.api.cafe.application.port.outbound.model
+
+import com.coffee.api.cafe.domain.Cafe
+import com.coffee.api.cafe.domain.CafeRecommendGroup
+import com.coffee.api.common.domain.SliceDomain
+
+data class CafeInfoWithRecommendGroups(
+    override val content: List<GroupedCafes>,
+    override val hasNext: Boolean,
+) : SliceDomain<CafeInfoWithRecommendGroups.GroupedCafes> {
+
+    data class GroupedCafes(
+        val group: CafeRecommendGroup,
+        val cafes: List<Cafe>,
+    )
+}

--- a/src/main/kotlin/com/coffee/api/cafe/domain/CafeRecommendGroup.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/domain/CafeRecommendGroup.kt
@@ -1,0 +1,22 @@
+package com.coffee.api.cafe.domain
+
+import com.coffee.api.common.domain.AbstractDomain
+import com.coffee.api.common.domain.UUIDTypeId
+import java.util.*
+
+data class CafeRecommendGroup(
+    override val id: Id,
+    val title: String,
+    val isVisible: Boolean,
+) : AbstractDomain<CafeRecommendGroup, CafeRecommendGroup.Id>() {
+
+    companion object {
+        operator fun invoke(
+            id: UUID,
+            title: String,
+            isVisible: Boolean,
+        ): CafeRecommendGroup = CafeRecommendGroup(Id(id), title, isVisible)
+    }
+
+    data class Id(override val value: UUID) : UUIDTypeId(value)
+}

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/CafeRecommendGroupConverter.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/CafeRecommendGroupConverter.kt
@@ -1,0 +1,28 @@
+package com.coffee.api.cafe.infrastructure
+
+import com.coffee.api.cafe.domain.CafeRecommendGroup
+import com.coffee.api.cafe.infrastructure.persistence.entity.CafeRecommendGroupEntity
+import com.coffee.api.common.infrastructure.persistence.DomainEntityConverter
+import org.springframework.stereotype.Component
+
+@Component
+class CafeRecommendGroupConverter : DomainEntityConverter<CafeRecommendGroup, CafeRecommendGroupEntity>(
+    CafeRecommendGroup::class,
+    CafeRecommendGroupEntity::class,
+) {
+    override fun toEntity(domain: CafeRecommendGroup): CafeRecommendGroupEntity {
+        return CafeRecommendGroupEntity(
+            id = domain.id.value,
+            title = domain.title,
+            isVisible = domain.isVisible,
+        )
+    }
+
+    override fun toDomain(entity: CafeRecommendGroupEntity): CafeRecommendGroup {
+        return CafeRecommendGroup(
+            id = entity.id,
+            title = entity.title,
+            isVisible = entity.isVisible,
+        )
+    }
+}

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupEntity.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupEntity.kt
@@ -1,0 +1,18 @@
+package com.coffee.api.cafe.infrastructure.persistence.entity
+
+import com.coffee.api.common.infrastructure.persistence.BaseEntity
+import jakarta.persistence.*
+import java.util.*
+
+@Entity
+@Table(name = "cafe_recommend_groups")
+class CafeRecommendGroupEntity(
+    @Id
+    val id: UUID,
+
+    @Column(nullable = false)
+    var title: String,
+
+    @Column(nullable = false)
+    var isVisible: Boolean = true,
+) : BaseEntity()

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupMappingEntity.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupMappingEntity.kt
@@ -5,14 +5,20 @@ import jakarta.persistence.*
 import java.util.*
 
 @Entity
-@Table(name = "cafe_recommend_group_mappings")
+@Table(
+    name = "cafe_recommend_group_mappings",
+    indexes = [
+        Index(name = "idx_cafe_recommend_group_mapping_cafe_id", columnList = "cafe_id"),
+        Index(name = "idx_cafe_recommend_group_mapping_group_id", columnList = "group_id")
+    ]
+)
 class CafeRecommendGroupMappingEntity(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "cafe_id")
+    @JoinColumn(name = "cafe_id", foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     var cafe: CafeEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_id")
+    @JoinColumn(name = "group_id", foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     var recommendGroup: CafeRecommendGroupEntity,
 
     @Id

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupMappingEntity.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupMappingEntity.kt
@@ -13,14 +13,15 @@ import java.util.*
     ]
 )
 class CafeRecommendGroupMappingEntity(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cafe_id", foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     var cafe: CafeEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id", foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
-    var recommendGroup: CafeRecommendGroupEntity,
+    var recommendGroup: CafeRecommendGroupEntity
 
-    @Id
-    val id: UUID = UUID.randomUUID(),
 ) : BaseEntity()

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupMappingEntity.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupMappingEntity.kt
@@ -14,7 +14,7 @@ import java.util.*
 )
 class CafeRecommendGroupMappingEntity(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: UUID,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cafe_id", foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT))

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupMappingEntity.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeRecommendGroupMappingEntity.kt
@@ -1,0 +1,20 @@
+package com.coffee.api.cafe.infrastructure.persistence.entity
+
+import com.coffee.api.common.infrastructure.persistence.BaseEntity
+import jakarta.persistence.*
+import java.util.*
+
+@Entity
+@Table(name = "cafe_recommend_group_mappings")
+class CafeRecommendGroupMappingEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    var cafe: CafeEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    var recommendGroup: CafeRecommendGroupEntity,
+
+    @Id
+    val id: UUID = UUID.randomUUID(),
+) : BaseEntity()

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/repository/CafeRepositoryImpl.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/repository/CafeRepositoryImpl.kt
@@ -4,7 +4,9 @@ import com.coffee.api.cafe.application.model.CafeDetails
 import com.coffee.api.cafe.application.model.CafeInfoWithTags
 import com.coffee.api.cafe.application.model.CafePage
 import com.coffee.api.cafe.application.port.outbound.CafeRepository
+import com.coffee.api.cafe.application.port.outbound.model.CafeInfoWithRecommendGroups
 import com.coffee.api.cafe.domain.*
+import com.coffee.api.cafe.infrastructure.CafeRecommendGroupConverter
 import com.coffee.api.cafe.infrastructure.CoffeeBeanConverter
 import com.coffee.api.cafe.infrastructure.MenuConverter
 import com.coffee.api.cafe.infrastructure.TagConverter
@@ -28,7 +30,8 @@ class CafeRepositoryImpl(
     private val menuConverter: MenuConverter,
     private val tagConverter: TagConverter,
     private val entityManager: EntityManager,
-    private val jpqlRenderContext: JpqlRenderContext
+    private val jpqlRenderContext: JpqlRenderContext,
+    private val cafeRecommendGroupConverter: CafeRecommendGroupConverter,
 ) : CafeRepository {
 
     override fun findAll(): List<Cafe> {
@@ -70,14 +73,12 @@ class CafeRepositoryImpl(
             CafeInfoWithTags.of(cafe, tags)
         }.take(limit)
 
-
         val hasNext = resultList.size > limit
         return CafePage.from(SliceImpl(
-            cafesWithTags,
-            Pageable.unpaged(), hasNext
-        ))
+                cafesWithTags,
+                Pageable.unpaged(), hasNext
+            ))
     }
-
 
     override fun findByCafeId(cafeId: UUID?): CafeDetails {
         // CafeEntity 조회
@@ -117,6 +118,59 @@ class CafeRepositoryImpl(
 
         // CafeDetails 객체 생성
         return CafeDetails.of(cafe, coffeeBean, menus, tags, updatedAt)
+    }
+
+    override fun findAllCafesInVisibleGroups(lastGroupId: UUID?, limit: Int): CafeInfoWithRecommendGroups {
+        val query = jpql {
+            select<Tuple>(
+                entity(CafeEntity::class),
+                entity(CafeRecommendGroupEntity::class),
+            )
+                .from(
+                    entity(CafeEntity::class),
+                    leftFetchJoin(CafeRecommendGroupMappingEntity::class)
+                        .on(entity(CafeEntity::class).eq(path(CafeRecommendGroupMappingEntity::cafe))),
+                    leftFetchJoin(CafeRecommendGroupEntity::class)
+                        .on(
+                            entity(
+                                CafeRecommendGroupEntity::class,
+                            ).eq(path(CafeRecommendGroupMappingEntity::recommendGroup)),
+                        ),
+                )
+                .whereAnd(
+                    path(CafeRecommendGroupEntity::isVisible).eq(true),
+                    path(CafeEntity::deletedAt).isNull(),
+                    lastGroupId?.let {
+                        path(CafeRecommendGroupEntity::id).greaterThan(it)
+                    },
+                )
+                .orderBy(path(CafeRecommendGroupEntity::id).asc())
+        }
+
+        val queryResult = entityManager
+            .createQuery(query, jpqlRenderContext)
+            .setMaxResults(limit + 1)
+            .resultList
+
+        val groupedResults = queryResult.groupBy(
+            { tuple -> tuple.get(1, CafeRecommendGroupEntity::class.java) },
+            { tuple -> tuple.get(0, CafeEntity::class.java) },
+        )
+
+        val groups = groupedResults.map { (groupEntity, cafeEntities) ->
+            CafeInfoWithRecommendGroups.GroupedCafes(
+                group = cafeRecommendGroupConverter.toDomain(groupEntity),
+                cafes = cafeEntities.filterNotNull().map { cafeConverter.toDomain(it) },
+            )
+        }
+
+        val hasNext = queryResult.size > limit
+        val slicedGroups = if (hasNext) groups.dropLast(1) else groups
+
+        return CafeInfoWithRecommendGroups(
+            slicedGroups,
+            hasNext,
+        )
     }
 
     private fun getMenusForCafe(cafeEntity: CafeEntity): List<Menu> {

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/controller/CafeController.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/controller/CafeController.kt
@@ -2,6 +2,7 @@ package com.coffee.api.cafe.presentation.adapter.controller
 
 import com.coffee.api.cafe.application.port.inbound.FindCafe
 import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
+import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
 import com.coffee.api.cafe.presentation.adapter.dto.response.*
 import com.coffee.api.cafe.presentation.docs.CafeApi
 import com.coffee.api.common.support.response.ApiResponse
@@ -17,6 +18,7 @@ import java.util.UUID
 class CafeController(
     val findCafe: FindCafe,
     val findCafeDetails: FindCafeDetails,
+    val findRecommendCafe: FindRecommendCafe,
 ) : CafeApi {
 
     @GetMapping
@@ -36,15 +38,15 @@ class CafeController(
                 tags = cafe.tags.map { tag ->
                     TagResponse(
                         id = tag.id.value.toString(),
-                        name = tag.name
+                        name = tag.name,
                     )
-                }
+                },
             )
         }
 
         val response = FindAllCafesResponseWrapper(
             cafes = cafes,
-            hasNext = result.hasNext
+            hasNext = result.hasNext,
         )
 
         return ApiResponse.success(response)
@@ -53,7 +55,7 @@ class CafeController(
     @GetMapping("/details/{cafeId}")
     override fun getCafeDetails(
         @PathVariable cafeId: UUID,
-        ): ApiResponse<GetCafeDetailsResponse> {
+    ): ApiResponse<GetCafeDetailsResponse> {
         val result = findCafeDetails.invoke(FindCafeDetails.Query(cafeId))
 
         val response = GetCafeDetailsResponse(
@@ -91,12 +93,17 @@ class CafeController(
             tags = result.cafeDetails.tag.map { tag ->
                 TagResponse(
                     id = tag.id.value.toString(),
-                    name = tag.name
+                    name = tag.name,
                 )
             },
             updatedAt = result.cafeDetails.updatedAt,
         )
 
         return ApiResponse.success(response)
+    }
+
+    @GetMapping("/recommend")
+    override fun getRecommendCafes(lastCafeId: UUID?, limit: Int): ApiResponse<FindRecommendCafe.Result> {
+        return ApiResponse.success(findRecommendCafe.execute(FindRecommendCafe.Query(lastCafeId, limit)))
     }
 }

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
@@ -30,14 +30,13 @@ interface CafeApi {
     fun getRecommendCafes(
         @Parameter(
             description = "마지막으로 조회된 카페 ID",
-            example = "123e4567-e89b-12d3-a456-426614174000",
         )
         @RequestParam(value = "lastCafeId", required = false)
         lastCafeId: UUID?,
 
         @Parameter(
             description = "한 번에 조회할 데이터 수",
-            example = "10",
+            example = "5",
             schema = Schema(
                 minimum = SliceConstants.MIN_LIMIT.toString(),
                 defaultValue = SliceConstants.DEFAULT_LIMIT.toString(),

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
@@ -1,9 +1,13 @@
 package com.coffee.api.cafe.presentation.docs
 
+import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
 import com.coffee.api.cafe.presentation.adapter.dto.response.FindAllCafesResponseWrapper
 import com.coffee.api.cafe.presentation.adapter.dto.response.GetCafeDetailsResponse
+import com.coffee.api.common.presentation.constant.SliceConstants
 import com.coffee.api.common.support.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
@@ -21,4 +25,25 @@ interface CafeApi {
     fun getCafeDetails(
         @PathVariable(value = "cafeId") cafeId: UUID,
     ): ApiResponse<GetCafeDetailsResponse>
+
+    @Operation(summary = "카페 추천 조회", description = "그룹화된 카페 추천을 조회합니다.")
+    fun getRecommendCafes(
+        @Parameter(
+            description = "마지막으로 조회된 카페 ID",
+            example = "123e4567-e89b-12d3-a456-426614174000",
+        )
+        @RequestParam(value = "lastCafeId", required = false)
+        lastCafeId: UUID?,
+
+        @Parameter(
+            description = "한 번에 조회할 데이터 수",
+            example = "10",
+            schema = Schema(
+                minimum = SliceConstants.MIN_LIMIT.toString(),
+                defaultValue = SliceConstants.DEFAULT_LIMIT.toString(),
+            ),
+        )
+        @RequestParam(value = "limit", required = false, defaultValue = SliceConstants.DEFAULT_LIMIT.toString())
+        limit: Int = 5,
+    ): ApiResponse<FindRecommendCafe.Result>
 }

--- a/src/main/kotlin/com/coffee/api/common/domain/SliceDomain.kt
+++ b/src/main/kotlin/com/coffee/api/common/domain/SliceDomain.kt
@@ -1,0 +1,6 @@
+package com.coffee.api.common.domain
+
+interface SliceDomain<T> {
+    val content: List<T>
+    val hasNext: Boolean
+}

--- a/src/main/kotlin/com/coffee/api/common/presentation/constant/SliceConstants.kt
+++ b/src/main/kotlin/com/coffee/api/common/presentation/constant/SliceConstants.kt
@@ -1,0 +1,6 @@
+package com.coffee.api.common.presentation.constant
+
+object SliceConstants {
+    const val DEFAULT_LIMIT = 5
+    const val MIN_LIMIT = 1
+}


### PR DESCRIPTION
## 관련 이슈
close #35 

## 주요 변경 사항
* 개발한 API는 다음 화면에서 쓰입니다.
<img width="429" alt="스크린샷 2025-01-28 오후 9 40 44" src="https://github.com/user-attachments/assets/82a63b97-51c2-4d5a-9e9a-9522e75ec6b7" />

* swagger 응답은 다음과 같습니다.
<img width="474" alt="스크린샷 2025-01-28 오후 9 45 09" src="https://github.com/user-attachments/assets/d77ce823-6ad7-4f92-9fe0-4fe3eb9548d5" />

## 기타
* 기존에 설계하신 의존성 방향, 디렉터리 구조와 일치하는지 확인부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 카페 추천 그룹 기능 추가
  - 사용자에게 추천 카페 목록을 제공하는 새로운 API 엔드포인트 구현
  - 마지막 카페 ID와 제한 매개변수를 통한 유연한 카페 검색 지원

- **개선 사항**
  - 카페 추천을 위한 새로운 도메인 및 인프라 레이어 구조 추가
  - 페이징 및 그룹화된 카페 검색 기능 도입
<!-- end of auto-generated comment: release notes by coderabbit.ai -->