### PR TITLE
[FEAT] 카페 필터링

### DIFF
--- a/src/main/kotlin/com/coffee/api/cafe/application/CafeAreaService.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/CafeAreaService.kt
@@ -1,0 +1,19 @@
+package com.coffee.api.cafe.application
+
+import com.coffee.api.cafe.application.port.inbound.FindCafeArea
+import com.coffee.api.cafe.application.port.outbound.CafeRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class CafeAreaService(
+    private val cafeRepository: CafeRepository,
+) : FindCafeArea {
+    override fun execute(input: Unit): FindCafeArea.Result {
+        val areas = cafeRepository.findAreas()
+        return FindCafeArea.Result(
+            areas.map { FindCafeArea.CafeAreaInfo(it.toString(), it.displayName) },
+        )
+    }
+}

--- a/src/main/kotlin/com/coffee/api/cafe/application/CafeService.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/CafeService.kt
@@ -2,6 +2,7 @@ package com.coffee.api.cafe.application
 
 import com.coffee.api.cafe.application.port.inbound.FindCafe
 import com.coffee.api.cafe.application.port.outbound.CafeRepository
+import com.coffee.api.cafe.domain.CafeArea
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,7 +13,19 @@ class CafeService(
 ) : FindCafe {
 
     override fun invoke(query: FindCafe.Query): FindCafe.Result {
-        val cafePage = cafeRepository.findAllCafesById(query.lastCafeId, 5)
-        return FindCafe.Result(cafePage.cafeInfoWithTags, cafePage.hasNext)
+        val area = query.area?.let { code ->
+            CafeArea.entries.find { it.name == code }
+        }
+
+        val cafePage = cafeRepository.findAllCafesById(
+            lastCafeId = query.lastCafeId,
+            area = area,
+            limit = 5,
+        )
+
+        return FindCafe.Result(
+            cafes = cafePage.cafeInfoWithTags,
+            hasNext = cafePage.hasNext,
+        )
     }
 }

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindCafe.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindCafe.kt
@@ -8,7 +8,8 @@ interface FindCafe {
     fun invoke(query: Query): Result
 
     data class Query(
-        val lastCafeId: UUID?
+        val lastCafeId: UUID?,
+        val area: String? = null,
     )
 
     data class Result(

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindCafeArea.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindCafeArea.kt
@@ -1,0 +1,15 @@
+package com.coffee.api.cafe.application.port.inbound
+
+import com.coffee.api.common.domain.UseCase
+
+interface FindCafeArea : UseCase<Unit, FindCafeArea.Result> {
+
+    data class Result(
+        val areas: List<CafeAreaInfo>,
+    )
+
+    data class CafeAreaInfo(
+        val code: String,
+        val displayName: String,
+    )
+}

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/CafeRepository.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/CafeRepository.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 
 interface CafeRepository {
     fun findAll(): List<Cafe>
-    fun findAllCafesById(lastCafeId: UUID?, limit: Int): CafePage
+    fun findAllCafesById(lastCafeId: UUID?, area: CafeArea?, limit: Int): CafePage
     fun findByCafeId(cafeId: UUID?): CafeDetails
     fun findAreas(): List<CafeArea>
 }

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/CafeRepository.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/CafeRepository.kt
@@ -1,12 +1,14 @@
 package com.coffee.api.cafe.application.port.outbound
 
 import com.coffee.api.cafe.application.model.CafeDetails
-import com.coffee.api.cafe.domain.Cafe
 import com.coffee.api.cafe.application.model.CafePage
+import com.coffee.api.cafe.domain.Cafe
+import com.coffee.api.cafe.domain.CafeArea
 import java.util.UUID
 
 interface CafeRepository {
     fun findAll(): List<Cafe>
     fun findAllCafesById(lastCafeId: UUID?, limit: Int): CafePage
     fun findByCafeId(cafeId: UUID?): CafeDetails
+    fun findAreas(): List<CafeArea>
 }

--- a/src/main/kotlin/com/coffee/api/cafe/domain/Cafe.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/domain/Cafe.kt
@@ -15,6 +15,7 @@ class Cafe private constructor(
     val price: Int,
     val previewImages: List<String>?,
     val mainImages: List<String>?,
+    val area: CafeArea,
 ) : AbstractDomain<Cafe, Cafe.Id>() {
     companion object {
         @JsonCreator
@@ -28,6 +29,7 @@ class Cafe private constructor(
             price: Int,
             previewImages: List<String>?,
             mainImages: List<String>?,
+            area: CafeArea,
         ): Cafe {
             return Cafe(
                 id = UUIDTypeId.from(id),
@@ -39,6 +41,7 @@ class Cafe private constructor(
                 price = price,
                 previewImages = previewImages,
                 mainImages = mainImages,
+                area = area,
             )
         }
 
@@ -52,7 +55,8 @@ class Cafe private constructor(
             price: Int,
             previewImages: List<String>?,
             mainImages: List<String>?,
-        ): Cafe = create(id, reasonForSelection, naverMapUrl, name, nearestStation, location, price, previewImages, mainImages)
+            area: CafeArea,
+        ): Cafe = create(id, reasonForSelection, naverMapUrl, name, nearestStation, location, price, previewImages, mainImages, area)
     }
 
     data class Id(override val value: UUID) : UUIDTypeId(value)

--- a/src/main/kotlin/com/coffee/api/cafe/domain/CafeArea.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/domain/CafeArea.kt
@@ -1,0 +1,16 @@
+package com.coffee.api.cafe.domain
+
+enum class CafeArea(val displayName: String) {
+    MYEONGDONG_HOEHYEON("명동성당/회현"),
+    DONGDAEMUN_BANGSAN("동대문/방산"),
+    CHEONGYE_JONGRO("청계/종로"),
+    BUKCHON_SAMCHEONG("북촌/삼청"),
+    CITYHALL_GWANGHWAMUN("시청/광화문"),
+    CHUNGMURO_EULJIRO("충무로/을지로"),
+    ;
+
+    companion object {
+        fun fromDisplayName(displayName: String) =
+            entries.find { it.displayName == displayName }
+    }
+}

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/CafeConverter.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/CafeConverter.kt
@@ -21,6 +21,7 @@ class CafeConverter : DomainEntityConverter<Cafe, CafeEntity>(
             price = entity.price,
             previewImages = entity.previewImages,
             mainImages = entity.mainImages,
+            area = entity.area,
         )
     }
 
@@ -35,6 +36,7 @@ class CafeConverter : DomainEntityConverter<Cafe, CafeEntity>(
             price = domain.price,
             previewImages = domain.previewImages ?: listOf(),
             mainImages = domain.mainImages ?: listOf(),
+            area = domain.area,
         )
     }
 }

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeEntity.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/entity/CafeEntity.kt
@@ -1,5 +1,6 @@
 package com.coffee.api.cafe.infrastructure.persistence.entity
 
+import com.coffee.api.cafe.domain.CafeArea
 import com.coffee.api.common.infrastructure.persistence.BaseEntity
 import jakarta.persistence.*
 import java.util.UUID
@@ -16,6 +17,7 @@ class CafeEntity(
     price: Int,
     previewImages: List<String>,
     mainImages: List<String>,
+    area: CafeArea,
 ) : BaseEntity() {
 
     @Id
@@ -47,7 +49,7 @@ class CafeEntity(
     @CollectionTable(
         name = "cafe_preview_images",
         joinColumns = [JoinColumn(name = "cafe_id")],
-        foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT)
+        foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT),
     )
     var previewImages: List<String> = previewImages
         protected set
@@ -56,8 +58,13 @@ class CafeEntity(
     @CollectionTable(
         name = "cafe_main_images",
         joinColumns = [JoinColumn(name = "cafe_id")],
-        foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT)
+        foreignKey = ForeignKey(value = ConstraintMode.NO_CONSTRAINT),
     )
     var mainImages: List<String> = mainImages
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "area", nullable = false)
+    var area: CafeArea = area
         protected set
 }

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/repository/CafeRepositoryImpl.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/repository/CafeRepositoryImpl.kt
@@ -36,7 +36,7 @@ class CafeRepositoryImpl(
             .map { cafeConverter.toDomain(it) }
     }
 
-    override fun findAllCafesById(lastCafeId: UUID?, limit: Int): CafePage {
+    override fun findAllCafesById(lastCafeId: UUID?, area: CafeArea?, limit: Int): CafePage {
         val query = jpql {
             select<Tuple>(entity(CafeEntity::class), entity(TagEntity::class))
                 .from(
@@ -49,6 +49,9 @@ class CafeRepositoryImpl(
                 .whereAnd(
                     lastCafeId?.let {
                         path(CafeEntity::id).greaterThan(it)
+                    },
+                    area?.let {
+                        path(CafeEntity::area).eq(it)
                     },
                     path(CafeEntity::deletedAt).isNull(),
                 )

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/controller/CafeController.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/controller/CafeController.kt
@@ -1,6 +1,7 @@
 package com.coffee.api.cafe.presentation.adapter.controller
 
 import com.coffee.api.cafe.application.port.inbound.FindCafe
+import com.coffee.api.cafe.application.port.inbound.FindCafeArea
 import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
 import com.coffee.api.cafe.presentation.adapter.dto.response.*
 import com.coffee.api.cafe.presentation.docs.CafeApi
@@ -17,6 +18,7 @@ import java.util.UUID
 class CafeController(
     val findCafe: FindCafe,
     val findCafeDetails: FindCafeDetails,
+    val findCafeArea: FindCafeArea,
 ) : CafeApi {
 
     @GetMapping
@@ -36,15 +38,15 @@ class CafeController(
                 tags = cafe.tags.map { tag ->
                     TagResponse(
                         id = tag.id.value.toString(),
-                        name = tag.name
+                        name = tag.name,
                     )
-                }
+                },
             )
         }
 
         val response = FindAllCafesResponseWrapper(
             cafes = cafes,
-            hasNext = result.hasNext
+            hasNext = result.hasNext,
         )
 
         return ApiResponse.success(response)
@@ -53,7 +55,7 @@ class CafeController(
     @GetMapping("/details/{cafeId}")
     override fun getCafeDetails(
         @PathVariable cafeId: UUID,
-        ): ApiResponse<GetCafeDetailsResponse> {
+    ): ApiResponse<GetCafeDetailsResponse> {
         val result = findCafeDetails.invoke(FindCafeDetails.Query(cafeId))
 
         val response = GetCafeDetailsResponse(
@@ -91,12 +93,18 @@ class CafeController(
             tags = result.cafeDetails.tag.map { tag ->
                 TagResponse(
                     id = tag.id.value.toString(),
-                    name = tag.name
+                    name = tag.name,
                 )
             },
             updatedAt = result.cafeDetails.updatedAt,
         )
 
+        return ApiResponse.success(response)
+    }
+
+    @GetMapping("/areas")
+    override fun getAreas(): ApiResponse<FindCafeArea.Result> {
+        val response = findCafeArea.execute(Unit)
         return ApiResponse.success(response)
     }
 }

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/controller/CafeController.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/controller/CafeController.kt
@@ -24,8 +24,9 @@ class CafeController(
     @GetMapping
     override fun findAllCafes(
         @RequestParam(value = "lastCafeId", required = false) lastCafeId: UUID?,
+        @RequestParam(value = "area", required = false) area: String?,
     ): ApiResponse<FindAllCafesResponseWrapper> {
-        val result = findCafe.invoke(FindCafe.Query(lastCafeId))
+        val result = findCafe.invoke(FindCafe.Query(lastCafeId, area))
 
         val cafes = result.cafes.map { cafe ->
             FindAllCafesResponse(

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
@@ -5,6 +5,7 @@ import com.coffee.api.cafe.presentation.adapter.dto.response.FindAllCafesRespons
 import com.coffee.api.cafe.presentation.adapter.dto.response.GetCafeDetailsResponse
 import com.coffee.api.common.support.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
@@ -16,6 +17,11 @@ interface CafeApi {
     @Operation(summary = "모든 카페 조회", description = "모든 카페를 조회합니다.")
     fun findAllCafes(
         @RequestParam(value = "lastCafeId", required = false) lastCafeId: UUID?,
+        @Parameter(
+            description = "필터링할 지역 코드(없으면 전체 조회)",
+            example = "MYEONGDONG_HOEHYEON",
+        )
+        @RequestParam(value = "area", required = false) area: String?,
     ): ApiResponse<FindAllCafesResponseWrapper>
 
     @Operation(summary = "카페 상세 조회", description = "cafeId로 해당 카페 정보를 상세 조회합니다.")

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
@@ -1,5 +1,6 @@
 package com.coffee.api.cafe.presentation.docs
 
+import com.coffee.api.cafe.application.port.inbound.FindCafeArea
 import com.coffee.api.cafe.presentation.adapter.dto.response.FindAllCafesResponseWrapper
 import com.coffee.api.cafe.presentation.adapter.dto.response.GetCafeDetailsResponse
 import com.coffee.api.common.support.response.ApiResponse
@@ -21,4 +22,10 @@ interface CafeApi {
     fun getCafeDetails(
         @PathVariable(value = "cafeId") cafeId: UUID,
     ): ApiResponse<GetCafeDetailsResponse>
+
+    @Operation(
+        summary = "카페 지역 목록 조회",
+        description = "카페를 필터링할 수 있는 지역 목록을 조회합니다.",
+    )
+    fun getAreas(): ApiResponse<FindCafeArea.Result>
 }


### PR DESCRIPTION
## 관련 이슈
close #31 

## 주요 변경 사항
* 조회할 수 있는 구역 정보 리스트 내려주는 API
<img width="230" alt="스크린샷 2025-01-29 오전 12 42 42" src="https://github.com/user-attachments/assets/f79439a5-6802-4c2c-9229-a610d1b88b42" />
<img width="797" alt="스크린샷 2025-01-29 오전 12 43 12" src="https://github.com/user-attachments/assets/14657e4b-d730-4208-bd5e-4e95da0f72b3" />

* 카페 조회 시 
<img width="795" alt="스크린샷 2025-01-29 오전 12 43 51" src="https://github.com/user-attachments/assets/2034e6f3-46c6-4c07-bdb2-abaaca49c6f1" />
구역 정보 필터링(없을 시 전체 조회)

## 기타
앞선 PR과 동일하게 패키지 구조가 설계하신 것과 일치하는지 중점으로 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 카페 지역별 필터링 기능 추가
	- 카페 지역 목록 조회 엔드포인트 신규 개발

- **개선 사항**
	- 카페 검색 시 지역 선택 옵션 제공
	- 카페 데이터 모델에 지역 정보 추가

- **지원 지역**
	- 명동/회현
	- 동대문/방산
	- 청계/종로
	- 북촌/삼청
	- 시청/광화문
	- 충무로/을지로

<!-- end of auto-generated comment: release notes by coderabbit.ai -->