### PR TITLE
[FEAT] prod 서버 에러 발생 시 디스코드 알림 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,9 @@ dependencies {
     implementation(Dependency.JDSL.JPQL_DSL)
     implementation(Dependency.JDSL.JPQL_RENDER)
     implementation(Dependency.JDSL.SPRING_DATA_JPA_SUPPORTER)
+
+    // Discord
+    implementation (Dependency.Discord.WEB_HOOK)
 }
 
 kotlin {

--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -55,4 +55,10 @@ object Dependency {
         val JPQL_RENDER = "$BASE:jpql-render:$JDSL_CORE_VERSION"
         val SPRING_DATA_JPA_SUPPORTER = "$BASE:spring-data-jpa-support:$JDSL_CORE_VERSION"
     }
+
+    object Discord {
+        private const val BASE = "org.springframework.boot"
+
+        val WEB_HOOK = "$BASE:spring-boot-starter-webflux"
+    }
 }

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
@@ -1,4 +1,4 @@
-package com.coffee.api.cafe.presentation.adapter.controller
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi
 
 import com.coffee.api.cafe.application.port.inbound.FindCafe
 import com.coffee.api.cafe.application.port.inbound.FindCafeArea

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/out/DiscordClientAdapter.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/out/DiscordClientAdapter.kt
@@ -1,0 +1,42 @@
+package com.coffee.api.cafe.presentation.adapter.out
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Component
+class DiscordClientAdapter(
+    @Value("\${discord.environment}") private val environment: String,
+    @Value("\${discord.webhook-url}") private val webhookUrl: String,
+) {
+
+    private val webClient: WebClient = WebClient.create()
+
+    fun sendErrorMessage(code: String, message: String, stackTrace: String) {
+        if (environment != "prod") return
+
+        val embedData = mapOf(
+            "title" to "BrewLounge 서버 에러 발생",
+            "fields" to listOf(
+                mapOf("name" to "발생시각", "value" to LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))),
+                mapOf("name" to "에러 코드", "value" to code.toString()),
+                mapOf("name" to "에러 명", "value" to message),
+                mapOf("name" to "스택 트레이스", "value" to stackTrace)
+            )
+        )
+
+        val payload = mapOf("embeds" to listOf(embedData))
+
+        webClient.post()
+            .uri(webhookUrl)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(payload)
+            .retrieve()
+            .bodyToMono<Void>()
+            .block()
+    }
+}

--- a/src/main/kotlin/com/coffee/api/config/ApiControllerAdvice.kt
+++ b/src/main/kotlin/com/coffee/api/config/ApiControllerAdvice.kt
@@ -1,5 +1,6 @@
 package com.coffee.api.config
 
+import com.coffee.api.cafe.presentation.adapter.out.DiscordClientAdapter
 import com.coffee.api.common.support.error.CoreApiException
 import com.coffee.api.common.support.error.ErrorType
 import com.coffee.api.common.support.response.ApiResponse
@@ -9,14 +10,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 
 @RestControllerAdvice
 @io.swagger.v3.oas.annotations.Hidden
-class ApiControllerAdvice {
+class ApiControllerAdvice(
+    private val discordClientAdapter: DiscordClientAdapter
+) {
     @ExceptionHandler(value = [CoreApiException::class])
     fun handleCoreApiException(e: CoreApiException): ResponseEntity<ApiResponse<Any>> {
+        discordClientAdapter.sendErrorMessage(e.errorType.toString(), e.errorType.status.toString(), e.data.toString())
         return ResponseEntity(ApiResponse.error(e.errorType, e.data), e.errorType.status)
     }
 
     @ExceptionHandler(value = [Exception::class])
     fun handleException(e: Exception): ResponseEntity<ApiResponse<Any>> {
+        discordClientAdapter.sendErrorMessage(ErrorType.DEFAULT_ERROR.code.toString(), e.message.toString(), ErrorType.DEFAULT_ERROR.status.toString())
         return ResponseEntity(ApiResponse.error(ErrorType.DEFAULT_ERROR, e.message), ErrorType.DEFAULT_ERROR.status)
     }
 }


### PR DESCRIPTION
## 관련 이슈
close #46 

## 주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.

에러 발생 전역 예외 aop를 통해 디스코드 메시지를 발송합니다.

## 기타
> 고려해야 하는 내용을 작성해 주세요.

간단한 웹훅 추가라 바로 머지합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - Discord 웹훅 연동이 추가되어, 프로덕션 환경에서 발생하는 오류를 Discord 채널로 자동 알림합니다.
  - 관련 의존성 및 오류 메시지 전송 기능이 도입되었습니다.

- **리팩토링**
  - CafeController의 패키지 구조가 개선되어 내부 코드 조직이 최적화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->