### PR TITLE
[FIX] 그룹을 기준으로 슬라이스 처리

### DIFF
--- a/src/main/kotlin/com/coffee/api/cafe/application/CafeRecommendGroupService.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/CafeRecommendGroupService.kt
@@ -11,7 +11,7 @@ class CafeRecommendGroupService(
     private val cafeRepository: CafeRepository,
 ) : FindRecommendCafe {
     override fun execute(input: FindRecommendCafe.Query): FindRecommendCafe.Result {
-        val result = cafeRepository.findAllCafesInVisibleGroups(input.lastCafeId, input.limit)
+        val result = cafeRepository.findAllCafesInVisibleGroups(input.lastGroupId, input.limit)
 
         val groups = result.content.map {
             FindRecommendCafe.CafeRecommendGroup(

--- a/src/main/kotlin/com/coffee/api/cafe/application/CafeRecommendGroupService.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/CafeRecommendGroupService.kt
@@ -16,6 +16,7 @@ class CafeRecommendGroupService(
         val groups = result.content.map {
             FindRecommendCafe.CafeRecommendGroup(
                 name = it.group.title,
+                groupId = it.group.id.value.toString(),
                 cafes = it.cafes.map { cafe ->
                     FindRecommendCafe.SimpleCafe(
                         id = cafe.id.value.toString(),

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindRecommendCafe.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindRecommendCafe.kt
@@ -17,6 +17,7 @@ interface FindRecommendCafe : UseCase<FindRecommendCafe.Query, FindRecommendCafe
 
     data class CafeRecommendGroup(
         val name: String,
+        val groupId : String,
         val cafes: List<SimpleCafe>,
     )
 

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindRecommendCafe.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/inbound/FindRecommendCafe.kt
@@ -6,7 +6,7 @@ import java.util.*
 interface FindRecommendCafe : UseCase<FindRecommendCafe.Query, FindRecommendCafe.Result> {
 
     data class Query(
-        val lastCafeId: UUID?,
+        val lastGroupId: UUID?,
         val limit: Int,
     )
 

--- a/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/CafeRepository.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/port/outbound/CafeRepository.kt
@@ -12,5 +12,5 @@ interface CafeRepository {
     fun findAllCafesById(lastCafeId: UUID?, area: CafeArea?, limit: Int): CafePage
     fun findByCafeId(cafeId: UUID?): CafeDetails
     fun findAreas(): List<CafeArea>
-    fun findAllCafesInVisibleGroups(lastCafeId: UUID?, limit: Int): CafeInfoWithRecommendGroups
+    fun findAllCafesInVisibleGroups(lastGroupId: UUID?, limit: Int): CafeInfoWithRecommendGroups
 }

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/repository/CafeRepositoryImpl.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/repository/CafeRepositoryImpl.kt
@@ -171,7 +171,6 @@ class CafeRepositoryImpl(
 
         val queryResult = entityManager
             .createQuery(query, jpqlRenderContext)
-            .setMaxResults(limit + 1)
             .resultList
 
         val groupedResults = queryResult.groupBy(
@@ -186,12 +185,12 @@ class CafeRepositoryImpl(
             )
         }
 
-        val hasNext = queryResult.size > limit
-        val slicedGroups = if (hasNext) groups.dropLast(1) else groups
+        val hasNext = groups.size > limit
+        val slicedContent = if (hasNext) groups.take(limit) else groups
 
         return CafeInfoWithRecommendGroups(
-            slicedGroups,
-            hasNext,
+            content = slicedContent,
+            hasNext = hasNext,
         )
     }
 

--- a/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/repository/CafeRepositoryImpl.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/infrastructure/persistence/repository/CafeRepositoryImpl.kt
@@ -193,7 +193,6 @@ class CafeRepositoryImpl(
             slicedGroups,
             hasNext,
         )
-
     }
 
     private fun getMenusForCafe(cafeEntity: CafeEntity): List<Menu> {

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/dto/response/TagResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/dto/response/TagResponse.kt
@@ -1,6 +1,0 @@
-package com.coffee.api.cafe.presentation.adapter.dto.response
-
-data class TagResponse(
-    val id: String,
-    val name: String,
-)

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
@@ -112,7 +112,7 @@ class CafeController(
     }
 
     @GetMapping("/recommend")
-    override fun getRecommendCafes(lastCafeId: UUID?, limit: Int): ApiResponse<FindRecommendCafe.Result> {
-        return ApiResponse.success(findRecommendCafe.execute(FindRecommendCafe.Query(lastCafeId, limit)))
+    override fun getRecommendCafes(lastGroupId: UUID?, limit: Int): ApiResponse<FindRecommendCafe.Result> {
+        return ApiResponse.success(findRecommendCafe.execute(FindRecommendCafe.Query(lastGroupId, limit)))
     }
 }

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
@@ -4,7 +4,7 @@ import com.coffee.api.cafe.application.port.inbound.FindCafe
 import com.coffee.api.cafe.application.port.inbound.FindCafeArea
 import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
 import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
-import com.coffee.api.cafe.presentation.adapter.dto.response.*
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.*
 import com.coffee.api.cafe.presentation.docs.CafeApi
 import com.coffee.api.common.support.response.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/CafeResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/CafeResponse.kt
@@ -1,4 +1,4 @@
-package com.coffee.api.cafe.presentation.adapter.dto.response
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
 
 data class CafeResponse(
     val id: String,

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/CoffeeBeanResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/CoffeeBeanResponse.kt
@@ -1,4 +1,4 @@
-package com.coffee.api.cafe.presentation.adapter.dto.response
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
 
 import com.coffee.api.cafe.domain.CountryOrigin
 

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/DetailTagResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/DetailTagResponse.kt
@@ -1,4 +1,4 @@
-package com.coffee.api.cafe.presentation.adapter.dto.response
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
 
 class DetailTagResponse(
     val id: String,

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponse.kt
@@ -1,4 +1,4 @@
-package com.coffee.api.cafe.presentation.adapter.dto.response
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
 
 
 data class FindAllCafesResponseWrapper(

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/GetCafeDetailsResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/GetCafeDetailsResponse.kt
@@ -1,4 +1,4 @@
-package com.coffee.api.cafe.presentation.adapter.dto.response
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import java.time.LocalDateTime

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/MenuResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/MenuResponse.kt
@@ -1,4 +1,4 @@
-package com.coffee.api.cafe.presentation.adapter.dto.response
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
 
 data class MenuResponse(
     val id: String,

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/TagResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/TagResponse.kt
@@ -1,0 +1,6 @@
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
+
+data class TagResponse(
+    val id: String,
+    val name: String,
+)

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
@@ -41,13 +41,13 @@ interface CafeApi {
     @Operation(summary = "카페 추천 조회", description = "그룹화된 카페 추천을 조회합니다.")
     fun getRecommendCafes(
         @Parameter(
-            description = "마지막으로 조회된 카페 ID",
+            description = "마지막으로 조회된 추천 카페 그룹 ID",
         )
-        @RequestParam(value = "lastCafeId", required = false)
-        lastCafeId: UUID?,
+        @RequestParam(value = "lastGroupId", required = false)
+        lastGroupId: UUID?,
 
         @Parameter(
-            description = "한 번에 조회할 데이터 수",
+            description = "한 번에 조회할 추천 카페 그룹 수",
             example = "5",
             schema = Schema(
                 minimum = SliceConstants.MIN_LIMIT.toString(),

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/docs/CafeApi.kt
@@ -2,8 +2,8 @@ package com.coffee.api.cafe.presentation.docs
 
 import com.coffee.api.cafe.application.port.inbound.FindCafeArea
 import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
-import com.coffee.api.cafe.presentation.adapter.dto.response.FindAllCafesResponseWrapper
-import com.coffee.api.cafe.presentation.adapter.dto.response.GetCafeDetailsResponse
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.FindAllCafesResponseWrapper
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.GetCafeDetailsResponse
 import com.coffee.api.common.presentation.constant.SliceConstants
 import com.coffee.api.common.support.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation


### PR DESCRIPTION
## 관련 이슈
close #49 

## 주요 변경 사항
기존에 카페 개수를 기준으로 슬라이스 처리 중이였습니다.
이를 그룹 개수를 기준으로 슬라이스 처리하도록 변경하였습니다.

## 기타
> 고려해야 하는 내용을 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 카페 추천 API가 그룹 기반으로 업데이트되어, 추천 결과에 그룹 식별자(groupId)가 추가되었습니다.
	- 추천 조회 요청 시 '마지막 조회된 추천 카페 그룹 ID'를 기준으로 페이징 처리됩니다.
- **Documentation**
	- API 문서 내 파라미터 설명 및 응답 데이터 형식이 변경된 그룹 기반 추천 정보를 반영하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->