### PR TITLE
[FIX] 유효하지 않은 area 전달 시 빈 배열 반환

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
 
     // Test
     testRuntimeOnly(Dependency.Test.JUNIT_PLATFORM)
+    testImplementation(Dependency.Test.MOCKK)
 
     // Database
     runtimeOnly(Dependency.Database.MYSQL_CONNECTOR)

--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -27,11 +27,13 @@ object Dependency {
 
     object Test {
         private const val JUNIT_VERSION = "1.10.2"
+        private const val MOCKK_VERSION = "1.13.9"
 
         private const val BASE = "org.junit.platform"
         fun junit(name: String) = "$BASE:$name:$JUNIT_VERSION"
 
         val JUNIT_PLATFORM = junit("junit-platform-launcher")
+        val MOCKK = "io.mockk:mockk:$MOCKK_VERSION"
     }
 
     object Database {

--- a/src/main/kotlin/com/coffee/api/cafe/application/CafeService.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/application/CafeService.kt
@@ -17,6 +17,13 @@ class CafeService(
             CafeArea.entries.find { it.name == code }
         }
 
+        if (query.area != null && area == null) {
+            return FindCafe.Result(
+                cafes = emptyList(),
+                hasNext = false
+            )
+        }
+
         val cafePage = cafeRepository.findAllCafesById(
             lastCafeId = query.lastCafeId,
             area = area,

--- a/src/test/kotlin/com/coffee/api/cafe/application/CafeServiceTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/application/CafeServiceTest.kt
@@ -1,0 +1,114 @@
+package com.coffee.api.cafe.application
+
+import com.coffee.api.cafe.application.model.CafePage
+import com.coffee.api.cafe.application.port.inbound.FindCafe
+import com.coffee.api.cafe.application.port.outbound.CafeRepository
+import com.coffee.api.cafe.domain.CafeArea
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CafeServiceTest {
+    private val cafeRepository = mockk<CafeRepository>()
+    private val cafeService = CafeService(cafeRepository)
+
+    @Test
+    @DisplayName("올바른 지역 코드로 카페를 조회하면 해당 지역의 카페 목록을 반환한다")
+    fun findCafesWithValidArea() {
+        // given
+        val lastCafeId = UUID.randomUUID()
+        val query = FindCafe.Query(
+            lastCafeId = lastCafeId,
+            area = CafeArea.CHEONGYE_JONGRO.name
+        )
+
+        val expectedCafePage = createCafePage(
+            cafeCount = 2,
+            hasNext = true
+        )
+
+        mockFindAllCafesById(
+            lastCafeId = lastCafeId,
+            area = CafeArea.CHEONGYE_JONGRO,
+            resultPage = expectedCafePage
+        )
+
+        // when
+        val result = cafeService.invoke(query)
+
+        // then
+        assertThat(result.cafes).hasSize(2)
+        assertThat(result.hasNext).isTrue()
+    }
+
+    @Test
+    @DisplayName("잘못된 지역 코드로 카페를 조회하면 빈 목록을 반환한다")
+    fun findCafesWithInvalidArea() {
+        // given
+        val query = FindCafe.Query(
+            lastCafeId = UUID.randomUUID(),
+            area = "INVALID_AREA"
+        )
+
+        // when
+        val result = cafeService.invoke(query)
+
+        // then
+        assertThat(result.cafes).isEmpty()
+        assertThat(result.hasNext).isFalse()
+    }
+
+    @Test
+    @DisplayName("지역 코드 없이 카페를 조회하면 전체 카페 목록을 반환한다")
+    fun findCafesWithoutArea() {
+        // given
+        val lastCafeId = UUID.randomUUID()
+        val query = FindCafe.Query(
+            lastCafeId = lastCafeId,
+            area = null
+        )
+
+        val expectedCafePage = createCafePage(
+            cafeCount = 3,
+            hasNext = false
+        )
+
+        mockFindAllCafesById(
+            lastCafeId = lastCafeId,
+            area = null,
+            resultPage = expectedCafePage
+        )
+
+        // when
+        val result = cafeService.invoke(query)
+
+        // then
+        assertThat(result.cafes).hasSize(3)
+        assertThat(result.hasNext).isFalse()
+    }
+
+    private fun createCafePage(
+        cafeCount: Int,
+        hasNext: Boolean
+    ) = CafePage(
+        cafeInfoWithTags = List(cafeCount) { mockk() },
+        hasNext = hasNext
+    )
+
+    private fun mockFindAllCafesById(
+        lastCafeId: UUID,
+        area: CafeArea?,
+        resultPage: CafePage
+    ) {
+        every {
+            cafeRepository.findAllCafesById(
+                lastCafeId = lastCafeId,
+                area = area,
+                limit = 5
+            )
+        } returns resultPage
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #52 

## 주요 변경 사항
* 유효하지 않은 area 시 빈 배열 반환하도록 변경했습니다.

## 기타
우선 자체 merge 하겠습니다!
추후 코멘트 및 리뷰 반영하겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 카페 검색 서비스가 유효하지 않은 지역 입력 시, 조기에 빈 결과와 페이지 없음 응답을 제공하도록 개선되었습니다.
  
- **Tests**
  - 다양한 지역 코드 처리(유효, 무효, 미입력)에 대한 단위 테스트가 추가되어 서비스의 신뢰성과 안정성이 향상되었습니다.
  
- **Chores**
  - 테스트 환경 강화를 위해 새로운 테스트 의존성이 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->