### PR TITLE
[REFACTOR] 컨트롤러 응답 매핑 로직 전담 매퍼로 분리 외 3가지 리팩터링

### DIFF
--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
@@ -5,6 +5,8 @@ import com.coffee.api.cafe.application.port.inbound.FindCafeArea
 import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
 import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
 import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.*
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper.FindAllCafesResponseMapper
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper.GetCafeDetailsResponseMapper
 import com.coffee.api.cafe.presentation.docs.CafeApi
 import com.coffee.api.common.support.response.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,29 +31,7 @@ class CafeController(
         @RequestParam(value = "area", required = false) area: String?,
     ): ApiResponse<FindAllCafesResponseWrapper> {
         val result = findCafe.invoke(FindCafe.Query(lastCafeId, area))
-
-        val cafes = result.cafes.map { cafe ->
-            FindAllCafesResponse(
-                cafeId = cafe.cafeId.value.toString(),
-                name = cafe.name,
-                nearestStation = cafe.nearestStation,
-                location = cafe.location,
-                price = cafe.price,
-                previewImages = cafe.previewImages,
-                tags = cafe.tags.map { tag ->
-                    TagResponse(
-                        id = tag.id.value.toString(),
-                        name = tag.name,
-                    )
-                },
-            )
-        }
-
-        val response = FindAllCafesResponseWrapper(
-            cafes = cafes,
-            hasNext = result.hasNext,
-        )
-
+        val response = FindAllCafesResponseMapper.toResponse(result)
         return ApiResponse.success(response)
     }
 
@@ -60,51 +40,7 @@ class CafeController(
         @PathVariable cafeId: UUID,
     ): ApiResponse<GetCafeDetailsResponse> {
         val result = findCafeDetails.invoke(FindCafeDetails.Query(cafeId))
-
-        val response = GetCafeDetailsResponse(
-            cafe = CafeResponse(
-                id = result.cafeDetails.cafe.id.value.toString(),
-                reasonForSelection = result.cafeDetails.cafe.reasonForSelection,
-                naverMapUrl = result.cafeDetails.cafe.naverMapUrl,
-                name = result.cafeDetails.cafe.name,
-                nearestStation = result.cafeDetails.cafe.nearestStation,
-                location = result.cafeDetails.cafe.location,
-                price = result.cafeDetails.cafe.price,
-                mainImageUrl = result.cafeDetails.cafe.mainImages,
-            ),
-            coffeeBean = CoffeeBeanResponse(
-                id = result.cafeDetails.coffeeBean.id.value.toString(),
-                description = result.cafeDetails.coffeeBean.description,
-                name = result.cafeDetails.coffeeBean.name,
-                engName = result.cafeDetails.coffeeBean.engName,
-                flavors = result.cafeDetails.coffeeBean.flavors.map { flavor ->
-                    FlavorResponse(
-                        flavor.displayName,
-                        flavor.category
-                    )
-                },
-                countryOfOrigin = result.cafeDetails.coffeeBean.countryOfOrigin,
-                roastingPoint = result.cafeDetails.coffeeBean.roastingPoint.toString(),
-            ),
-            menus = result.cafeDetails.menu.map { menu ->
-                MenuResponse(
-                    id = menu.id.value.toString(),
-                    name = menu.name,
-                    price = menu.price,
-                    imageUrl = menu.imageUrl,
-                    description = menu.description,
-                )
-            },
-            tags = result.cafeDetails.tag.map { tag ->
-                DetailTagResponse(
-                    id = tag.id.value.toString(),
-                    name = tag.name,
-                    imageUrl = tag.imageUrl
-                )
-            },
-            updatedAt = result.cafeDetails.updatedAt,
-        )
-
+        val response = GetCafeDetailsResponseMapper.toResponse(result)
         return ApiResponse.success(response)
     }
 

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponse.kt
@@ -1,11 +1,6 @@
 package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
 
 
-data class FindAllCafesResponseWrapper(
-    val cafes: List<FindAllCafesResponse>,
-    val hasNext: Boolean
-)
-
 data class FindAllCafesResponse(
     val cafeId: String,
     val name: String,

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponseWrapper.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponseWrapper.kt
@@ -1,0 +1,6 @@
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
+
+data class FindAllCafesResponseWrapper(
+    val cafes: List<FindAllCafesResponse>,
+    val hasNext: Boolean
+)

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/mapper/FindAllCafesResponseMapper.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/mapper/FindAllCafesResponseMapper.kt
@@ -1,0 +1,31 @@
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper
+
+import com.coffee.api.cafe.application.port.inbound.FindCafe
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.FindAllCafesResponse
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.FindAllCafesResponseWrapper
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.TagResponse
+
+object FindAllCafesResponseMapper {
+    fun toResponse(result: FindCafe.Result): FindAllCafesResponseWrapper {
+        val cafes = result.cafes.map { cafe ->
+            FindAllCafesResponse(
+                cafeId = cafe.cafeId.value.toString(),
+                name = cafe.name,
+                nearestStation = cafe.nearestStation,
+                location = cafe.location,
+                price = cafe.price,
+                previewImages = cafe.previewImages,
+                tags = cafe.tags.map { tag ->
+                    TagResponse(
+                        id = tag.id.value.toString(),
+                        name = tag.name,
+                    )
+                }
+            )
+        }
+        return FindAllCafesResponseWrapper(
+            cafes = cafes,
+            hasNext = result.hasNext,
+        )
+    }
+}

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/mapper/GetCafeDetailsResponseMapper.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/mapper/GetCafeDetailsResponseMapper.kt
@@ -1,0 +1,52 @@
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper
+
+import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.*
+
+object GetCafeDetailsResponseMapper {
+    fun toResponse(result: FindCafeDetails.Result): GetCafeDetailsResponse {
+        return GetCafeDetailsResponse(
+            cafe = CafeResponse(
+                id = result.cafeDetails.cafe.id.value.toString(),
+                reasonForSelection = result.cafeDetails.cafe.reasonForSelection,
+                naverMapUrl = result.cafeDetails.cafe.naverMapUrl,
+                name = result.cafeDetails.cafe.name,
+                nearestStation = result.cafeDetails.cafe.nearestStation,
+                location = result.cafeDetails.cafe.location,
+                price = result.cafeDetails.cafe.price,
+                mainImageUrl = result.cafeDetails.cafe.mainImages,
+            ),
+            coffeeBean = CoffeeBeanResponse(
+                id = result.cafeDetails.coffeeBean.id.value.toString(),
+                description = result.cafeDetails.coffeeBean.description,
+                name = result.cafeDetails.coffeeBean.name,
+                engName = result.cafeDetails.coffeeBean.engName,
+                flavors = result.cafeDetails.coffeeBean.flavors.map { flavor ->
+                    FlavorResponse(
+                        flavor.displayName,
+                        flavor.category
+                    )
+                },
+                countryOfOrigin = result.cafeDetails.coffeeBean.countryOfOrigin,
+                roastingPoint = result.cafeDetails.coffeeBean.roastingPoint.toString(),
+            ),
+            menus = result.cafeDetails.menu.map { menu ->
+                MenuResponse(
+                    id = menu.id.value.toString(),
+                    name = menu.name,
+                    price = menu.price,
+                    imageUrl = menu.imageUrl,
+                    description = menu.description,
+                )
+            },
+            tags = result.cafeDetails.tag.map { tag ->
+                DetailTagResponse(
+                    id = tag.id.value.toString(),
+                    name = tag.name,
+                    imageUrl = tag.imageUrl
+                )
+            },
+            updatedAt = result.cafeDetails.updatedAt
+        )
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #17 

## 주요 변경 사항

- **컨트롤러 리팩토링:**  
  Controller 내의 DTO 변환 로직을 분리하여, 별도의 Mapper 클래스를 통해 응답 DTO를 생성하도록 개선하였습니다.  
  '만들면서 배우는 클린 아키텍처' 책 내의 권장 사항인 클래스는 가능한 짧게 만들라는 조언을 적극 반영하였습니다.
  (FindAllCafesResponseMapper 및 GetCafeDetailsResponseMapper 도입)

- **패키지 구조 정리:**  
  초기 레이어드 아키텍처에서 헥사고날/클린 아키텍처로 점진 변경한 기존 구조에서,  
  몇 가지 문제점(Controller 코드 과다, converter 클래스 명칭 등)을 개선하는 방향으로 리팩토링 진행 중입니다.

- **코드 정리 후 커밋 할 것들:**  
  - infrastructure 계층의 converter를 mapper로 이름 변경  
  - application 계층의 model 패키지 명확화(예: UseCase로 변경 검토)  
  - common 패키지의 역할 분리 및 명확화  

## 진행 상황

### 기존의 패키지 구조

```java
   src
    ├─main
    │  ├─kotlin
    │  │  └─com
    │  │      └─coffee
    │  │          └─api
    │  │              ├─cafe
    │  │              │  ├─application
    │  │              │  │  ├─model
    │  │              │  │  └─port
    │  │              │  │      ├─inbound
    │  │              │  │      └─outbound
    │  │              │  │          └─model
    │  │              │  ├─domain
    │  │              │  ├─infrastructure
    │  │              │  │  └─persistence
    │  │              │  │      ├─entity
    │  │              │  │      └─repository
    │  │              │  └─presentation
    │  │              │      ├─adapter
    │  │              │      │  ├─in
    │  │              │      │  │  └─restapi
    │  │              │      │  │      └─dto
    │  │              │      │  │          └─response
    │  │              │      │  └─out
    │  │              │      └─docs
    │  │              ├─common
    │  │              │  ├─domain
    │  │              │  ├─infrastructure
    │  │              │  │  └─persistence
    │  │              │  ├─presentation
    │  │              │  │  └─constant
    │  │              │  └─support
    │  │              │      ├─error
    │  │              │      └─response
    │  │              ├─config
    │  │              └─helper
    │  │                  └─uuid
    │  └─resources
    └─test

```

지금의 패키지 구조는 프로젝트 초기의 레이어드 아키텍처에서 점진적으로 헥사고날 아키텍처로 변경시킨 패키지 구조입니다.

기존 레이어드 아키텍처에서 클린 아키텍처로 많은 부분을 수정했지만, 아키텍처 부분에 여전히 아쉬운 부분이 있었습니다.

바로,

- Controller 클래스의 코드가 dto 변환으로 너무 길다.
- infrastructure 계층의 converter라는 클래스명
- application 계층의 model 패키지의 의미의 모호함
- common 패키지의 명확한 역할 구분

이 네 가지 문제를 코드를 refactoring 하면서 해결해보겠습니다.

### 1. Controller 클래스 안의 dto 변환 코드를 mapper로 분리

Controller 의 코드가 response dto 변환으로 인해 과도하게 커지는 문제가 발생했습니다.

기본적으로 클래스 마다 코드는 짧고 분리할 수 있으면 분리를 최대한 하는게 가독성과 유지보수성에 큰 영향을 주기 때문에 mapper로 분리하여 관리하도록 수정을 진행했습니다.

```kotlin
@RestController
@RequestMapping("/api/v1/cafes")
class CafeController(
    val findCafe: FindCafe,
    val findCafeDetails: FindCafeDetails,
    val findCafeArea: FindCafeArea,
    val findRecommendCafe: FindRecommendCafe,
) : CafeApi {

    @GetMapping
    override fun findAllCafes(
        @RequestParam(value = "lastCafeId", required = false) lastCafeId: UUID?,
        @RequestParam(value = "area", required = false) area: String?,
    ): ApiResponse<FindAllCafesResponseWrapper> {
        val result = findCafe.invoke(FindCafe.Query(lastCafeId, area))

        val cafes = result.cafes.map { cafe ->
            FindAllCafesResponse(
                cafeId = cafe.cafeId.value.toString(),
                name = cafe.name,
                nearestStation = cafe.nearestStation,
                location = cafe.location,
                price = cafe.price,
                previewImages = cafe.previewImages,
                tags = cafe.tags.map { tag ->
                    TagResponse(
                        id = tag.id.value.toString(),
                        name = tag.name,
                    )
                },
            )
        }

        val response = FindAllCafesResponseWrapper(
            cafes = cafes,
            hasNext = result.hasNext,
        )

        return ApiResponse.success(response)
    }
```

위 코드는 기존 모든 카페를 커서 방식으로 반환하는 findAllCafe 의 컨트롤러입니다.

컨트롤러 코드를 간결하게 만들기 위해 기존에 매핑이 없는 전략(도메인 그대로 전달)에서

Mapping 을 활용하여 도메인 데이터를 dto로 변환하는 코드를 추가하여 매핑 계층을 만들어 

계층을 좀 더 분리하여 도메인이 오염되지 않도록 수정하려 했습니다.

프로젝트 전체적으로는 철저한 클린 아키텍처 구현을 목표로 양방향 매핑을 염두해두고 리팩터링을 해나갈 예정입니다.

수정된 CafeController 코드

```kotlin
@GetMapping
    override fun findAllCafes(
        @RequestParam(value = "lastCafeId", required = false) lastCafeId: UUID?,
        @RequestParam(value = "area", required = false) area: String?,
    ): ApiResponse<FindAllCafesResponseWrapper> {
        val result = findCafe.invoke(FindCafe.Query(lastCafeId, area))
        val response = FindAllCafesResponseMapper.toResponse(result)
        return ApiResponse.success(response)
    }
```

(CafeController의 getCafeDetails(카페 상세조회)도 마찬가지로 적용하여 매퍼로 dto변환 코드를 분리하였습니다.)

### infrastrcuture 계층의 converter 클래스를 mapper로 변경

작성중

### model → usecase?

작성중

### common 패키지의 현재 역할과 다른 사람들 코드 살펴보고 명확한 역할 구분하기

작성중

### 개선된 패키지 구조

남은 커밋 완료 후 함께 작성 예정

## 배경 및 목표

YAPP 25기가 종료된 후, 브루라운지팀은 프로젝트 런칭 및 지속적인 유지보수를 위해  
안정적 서버 운영, 클린 아키텍처와 DDD 적용, 실용적인 테스트 코드 작성 등을 목표로  
리팩토링을 진행하기로 결정하였습니다. 이번 PR은 그 첫 걸음으로,  
컨트롤러의 응답 매핑 로직을 분리하여 코드의 가독성과 유지보수성을 향상시키는 데 중점을 두었습니다.


## 기타

- 안정적 기능 구현 후 클린 아키텍처로의 전환 권고에 따라,  
  기존의 기능은 그대로 유지하면서 구조 개선만을 목표로 진행하였습니다.
- 향후 커밋들에서 추가적인 리팩토링(패키지 재정의, UseCase 네이밍 등)을 계획 중입니다.