### PR TITLE
[REFACTOR] controller 슬라이스 테스트 추가, mapper 계층 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     id(Plugin.OPENAPI.id) version Plugin.OPENAPI.version
     id(Plugin.ECLIPSE_APT.id) version Plugin.ECLIPSE_APT.version
     id(Plugin.KTLINT.id) version Plugin.KTLINT.version
-    id("org.asciidoctor.jvm.convert") version "3.3.2"
+    id(Plugin.ASCIIDOCTOR.id) version Plugin.ASCIIDOCTOR.version
 }
 
 allOpen {
@@ -58,8 +58,8 @@ dependencies {
     testImplementation(Dependency.Test.MOCKK)
 
     // Kotest
-    testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
-    testImplementation("io.kotest:kotest-assertions-core:5.9.0")
+    testImplementation(Dependency.Test.KOTEST_RUNNER)
+    testImplementation(Dependency.Test.KOTEST_ASSERTIONS_CORE)
 
     // Database
     runtimeOnly(Dependency.Database.MYSQL_CONNECTOR)
@@ -70,7 +70,7 @@ dependencies {
     // Docs
     implementation(Dependency.Spring.SPRINGDOC)
     add("asciidoctorExt", "org.springframework.restdocs:spring-restdocs-asciidoctor")
-    testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
+    testImplementation(Dependency.Spring.RESTDOCS_MOCKMVC)
 
     // JDSL
     implementation(Dependency.JDSL.JPQL_DSL)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.asciidoctor.gradle.jvm.AsciidoctorTask
+
 plugins {
     kotlin("jvm") version Plugin.KOTLIN_JVM.version
     kotlin("plugin.spring") version Plugin.KOTLIN_SPRING.version
@@ -9,6 +11,7 @@ plugins {
     id(Plugin.OPENAPI.id) version Plugin.OPENAPI.version
     id(Plugin.ECLIPSE_APT.id) version Plugin.ECLIPSE_APT.version
     id(Plugin.KTLINT.id) version Plugin.KTLINT.version
+    id("org.asciidoctor.jvm.convert") version "3.3.2"
 }
 
 allOpen {
@@ -23,6 +26,14 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+}
+
+configurations {
+    getByName("compileOnly") {
+        extendsFrom(configurations["annotationProcessor"])
+    }
+
+    create("asciidoctorExt")
 }
 
 repositories {
@@ -46,6 +57,10 @@ dependencies {
     testRuntimeOnly(Dependency.Test.JUNIT_PLATFORM)
     testImplementation(Dependency.Test.MOCKK)
 
+    // Kotest
+    testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
+    testImplementation("io.kotest:kotest-assertions-core:5.9.0")
+
     // Database
     runtimeOnly(Dependency.Database.MYSQL_CONNECTOR)
 
@@ -54,6 +69,8 @@ dependencies {
 
     // Docs
     implementation(Dependency.Spring.SPRINGDOC)
+    add("asciidoctorExt", "org.springframework.restdocs:spring-restdocs-asciidoctor")
+    testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
 
     // JDSL
     implementation(Dependency.JDSL.JPQL_DSL)
@@ -70,10 +87,33 @@ kotlin {
     }
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 
 tasks.withType<org.jmailen.gradle.kotlinter.tasks.LintTask> {
     enabled = false
+}
+
+val snippetsDir = file("build/generated-snippets")
+
+tasks.test {
+    outputs.dir(snippetsDir)
+}
+
+tasks.named<AsciidoctorTask>("asciidoctor") {
+    inputs.dir(snippetsDir)
+    configurations("asciidoctorExt")
+    sources {
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile()
+    dependsOn(tasks.test)
+}
+
+tasks.bootJar {
+    dependsOn(tasks.named<AsciidoctorTask>("asciidoctor"))
+    from(tasks.named<AsciidoctorTask>("asciidoctor").get().outputDir) {
+        into("static/docs")
+    }
 }

--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -13,6 +13,7 @@ object Dependency {
         val BOOT_STARTER_JPA = starter("-data-jpa")
         val BOOT_STARTER_ACTUATOR = starter("-actuator")
         val SPRINGDOC = "org.springdoc:springdoc-openapi-starter-webmvc-ui:$SPRINGDOC_VERSION"
+        val RESTDOCS_MOCKMVC = "org.springframework.restdocs:spring-restdocs-mockmvc"
     }
 
     object Kotlin {
@@ -28,12 +29,16 @@ object Dependency {
     object Test {
         private const val JUNIT_VERSION = "1.10.2"
         private const val MOCKK_VERSION = "1.13.9"
+        private const val KOTEST_RUNNER_VERSION = "5.8.0"
+        private const val KOTEST_ASSERTIONS_CORE_VERSION = "5.9.0"
 
         private const val BASE = "org.junit.platform"
         fun junit(name: String) = "$BASE:$name:$JUNIT_VERSION"
 
         val JUNIT_PLATFORM = junit("junit-platform-launcher")
         val MOCKK = "io.mockk:mockk:$MOCKK_VERSION"
+        val KOTEST_RUNNER = "io.kotest:kotest-runner-junit5:$KOTEST_RUNNER_VERSION"
+        val KOTEST_ASSERTIONS_CORE = "io.kotest:kotest-assertions-core:$KOTEST_ASSERTIONS_CORE_VERSION"
     }
 
     object Database {

--- a/buildSrc/src/main/kotlin/Plugin.kt
+++ b/buildSrc/src/main/kotlin/Plugin.kt
@@ -2,16 +2,26 @@ enum class Plugin(
     val id: String,
     val version: String
 ) {
+    // Kotlin
     KOTLIN_JVM("org.jetbrains.kotlin.jvm", "1.9.25"),
     KOTLIN_SPRING("org.jetbrains.kotlin.plugin.spring", "1.9.25"),
     KOTLIN_JPA("org.jetbrains.kotlin.plugin.jpa", "1.9.25"),
     KOTLIN_ALLOPEN("org.jetbrains.kotlin.plugin.allopen", "1.9.25"),
     KOTLIN_NOARG("org.jetbrains.kotlin.plugin.noarg", "1.9.25"),
+
+    // Lint
     KTLINT("org.jmailen.kotlinter", "3.16.0"),
 
+    // Spring
     SPRING_BOOT("org.springframework.boot", "3.4.1"),
     SPRING_DEPENDENCY_MANAGEMENT("io.spring.dependency-management", "1.1.7"),
 
+    // OpenAPI
     OPENAPI("org.openapi.generator", "6.5.0"),
-    ECLIPSE_APT("com.diffplug.eclipse.apt", "3.26.0");
+
+    // Eclipse APT
+    ECLIPSE_APT("com.diffplug.eclipse.apt", "3.26.0"),
+
+    // Asciidoctor
+    ASCIIDOCTOR("org.asciidoctor.jvm.convert", "3.3.2");
 }

--- a/src/docs/asciidoc/api/cafe/cafe.adoc
+++ b/src/docs/asciidoc/api/cafe/cafe.adoc
@@ -1,0 +1,6 @@
+// [[cafe-]]
+=== 카페 조회
+
+=== HTTP Request
+
+=== HTTP Response

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,15 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= Coffee REST API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc:left
+:toclevels: 2
+:sectlinks:
+
+[[Cafe-API]]
+== Cafe API
+
+include::api/cafe/cafe.adoc[]

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeController.kt
@@ -5,6 +5,8 @@ import com.coffee.api.cafe.application.port.inbound.FindCafeArea
 import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
 import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
 import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.*
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper.FindAllCafesResponseMapper
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper.GetCafeDetailsResponseMapper
 import com.coffee.api.cafe.presentation.docs.CafeApi
 import com.coffee.api.common.support.response.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,29 +31,7 @@ class CafeController(
         @RequestParam(value = "area", required = false) area: String?,
     ): ApiResponse<FindAllCafesResponseWrapper> {
         val result = findCafe.invoke(FindCafe.Query(lastCafeId, area))
-
-        val cafes = result.cafes.map { cafe ->
-            FindAllCafesResponse(
-                cafeId = cafe.cafeId.value.toString(),
-                name = cafe.name,
-                nearestStation = cafe.nearestStation,
-                location = cafe.location,
-                price = cafe.price,
-                previewImages = cafe.previewImages,
-                tags = cafe.tags.map { tag ->
-                    TagResponse(
-                        id = tag.id.value.toString(),
-                        name = tag.name,
-                    )
-                },
-            )
-        }
-
-        val response = FindAllCafesResponseWrapper(
-            cafes = cafes,
-            hasNext = result.hasNext,
-        )
-
+        val response = FindAllCafesResponseMapper.toResponse(result)
         return ApiResponse.success(response)
     }
 
@@ -60,51 +40,7 @@ class CafeController(
         @PathVariable cafeId: UUID,
     ): ApiResponse<GetCafeDetailsResponse> {
         val result = findCafeDetails.invoke(FindCafeDetails.Query(cafeId))
-
-        val response = GetCafeDetailsResponse(
-            cafe = CafeResponse(
-                id = result.cafeDetails.cafe.id.value.toString(),
-                reasonForSelection = result.cafeDetails.cafe.reasonForSelection,
-                naverMapUrl = result.cafeDetails.cafe.naverMapUrl,
-                name = result.cafeDetails.cafe.name,
-                nearestStation = result.cafeDetails.cafe.nearestStation,
-                location = result.cafeDetails.cafe.location,
-                price = result.cafeDetails.cafe.price,
-                mainImageUrl = result.cafeDetails.cafe.mainImages,
-            ),
-            coffeeBean = CoffeeBeanResponse(
-                id = result.cafeDetails.coffeeBean.id.value.toString(),
-                description = result.cafeDetails.coffeeBean.description,
-                name = result.cafeDetails.coffeeBean.name,
-                engName = result.cafeDetails.coffeeBean.engName,
-                flavors = result.cafeDetails.coffeeBean.flavors.map { flavor ->
-                    FlavorResponse(
-                        flavor.displayName,
-                        flavor.category
-                    )
-                },
-                countryOfOrigin = result.cafeDetails.coffeeBean.countryOfOrigin,
-                roastingPoint = result.cafeDetails.coffeeBean.roastingPoint.toString(),
-            ),
-            menus = result.cafeDetails.menu.map { menu ->
-                MenuResponse(
-                    id = menu.id.value.toString(),
-                    name = menu.name,
-                    price = menu.price,
-                    imageUrl = menu.imageUrl,
-                    description = menu.description,
-                )
-            },
-            tags = result.cafeDetails.tag.map { tag ->
-                DetailTagResponse(
-                    id = tag.id.value.toString(),
-                    name = tag.name,
-                    imageUrl = tag.imageUrl
-                )
-            },
-            updatedAt = result.cafeDetails.updatedAt,
-        )
-
+        val response = GetCafeDetailsResponseMapper.toResponse(result)
         return ApiResponse.success(response)
     }
 

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponse.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponse.kt
@@ -1,11 +1,6 @@
 package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
 
 
-data class FindAllCafesResponseWrapper(
-    val cafes: List<FindAllCafesResponse>,
-    val hasNext: Boolean
-)
-
 data class FindAllCafesResponse(
     val cafeId: String,
     val name: String,

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponseWrapper.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/dto/response/FindAllCafesResponseWrapper.kt
@@ -1,0 +1,6 @@
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response
+
+data class FindAllCafesResponseWrapper(
+    val cafes: List<FindAllCafesResponse>,
+    val hasNext: Boolean
+)

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/mapper/FindAllCafesResponseMapper.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/mapper/FindAllCafesResponseMapper.kt
@@ -1,0 +1,31 @@
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper
+
+import com.coffee.api.cafe.application.port.inbound.FindCafe
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.FindAllCafesResponse
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.FindAllCafesResponseWrapper
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.TagResponse
+
+object FindAllCafesResponseMapper {
+    fun toResponse(result: FindCafe.Result): FindAllCafesResponseWrapper {
+        val cafes = result.cafes.map { cafe ->
+            FindAllCafesResponse(
+                cafeId = cafe.cafeId.value.toString(),
+                name = cafe.name,
+                nearestStation = cafe.nearestStation,
+                location = cafe.location,
+                price = cafe.price,
+                previewImages = cafe.previewImages,
+                tags = cafe.tags.map { tag ->
+                    TagResponse(
+                        id = tag.id.value.toString(),
+                        name = tag.name,
+                    )
+                }
+            )
+        }
+        return FindAllCafesResponseWrapper(
+            cafes = cafes,
+            hasNext = result.hasNext,
+        )
+    }
+}

--- a/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/mapper/GetCafeDetailsResponseMapper.kt
+++ b/src/main/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/mapper/GetCafeDetailsResponseMapper.kt
@@ -1,0 +1,52 @@
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper
+
+import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.dto.response.*
+
+object GetCafeDetailsResponseMapper {
+    fun toResponse(result: FindCafeDetails.Result): GetCafeDetailsResponse {
+        return GetCafeDetailsResponse(
+            cafe = CafeResponse(
+                id = result.cafeDetails.cafe.id.value.toString(),
+                reasonForSelection = result.cafeDetails.cafe.reasonForSelection,
+                naverMapUrl = result.cafeDetails.cafe.naverMapUrl,
+                name = result.cafeDetails.cafe.name,
+                nearestStation = result.cafeDetails.cafe.nearestStation,
+                location = result.cafeDetails.cafe.location,
+                price = result.cafeDetails.cafe.price,
+                mainImageUrl = result.cafeDetails.cafe.mainImages,
+            ),
+            coffeeBean = CoffeeBeanResponse(
+                id = result.cafeDetails.coffeeBean.id.value.toString(),
+                description = result.cafeDetails.coffeeBean.description,
+                name = result.cafeDetails.coffeeBean.name,
+                engName = result.cafeDetails.coffeeBean.engName,
+                flavors = result.cafeDetails.coffeeBean.flavors.map { flavor ->
+                    FlavorResponse(
+                        flavor.displayName,
+                        flavor.category
+                    )
+                },
+                countryOfOrigin = result.cafeDetails.coffeeBean.countryOfOrigin,
+                roastingPoint = result.cafeDetails.coffeeBean.roastingPoint.toString(),
+            ),
+            menus = result.cafeDetails.menu.map { menu ->
+                MenuResponse(
+                    id = menu.id.value.toString(),
+                    name = menu.name,
+                    price = menu.price,
+                    imageUrl = menu.imageUrl,
+                    description = menu.description,
+                )
+            },
+            tags = result.cafeDetails.tag.map { tag ->
+                DetailTagResponse(
+                    id = tag.id.value.toString(),
+                    name = tag.name,
+                    imageUrl = tag.imageUrl
+                )
+            },
+            updatedAt = result.cafeDetails.updatedAt
+        )
+    }
+}

--- a/src/test/kotlin/com/coffee/ControllerTestSupport.kt
+++ b/src/test/kotlin/com/coffee/ControllerTestSupport.kt
@@ -1,0 +1,35 @@
+package com.coffee
+
+import com.coffee.api.cafe.application.port.inbound.FindCafe
+import com.coffee.api.cafe.application.port.inbound.FindCafeArea
+import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
+import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.CafeController
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper.FindAllCafesResponseMapper
+import com.coffee.api.cafe.presentation.adapter.out.DiscordClientAdapter
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.mockk
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MockMvcBuilder
+
+@WebMvcTest(
+    controllers = [
+        CafeController::class
+    ]
+)
+@Import(MockBeansConfig::class)
+abstract class ControllerTestSupport {
+
+    @Autowired
+    protected lateinit var mockMvc: MockMvc;
+
+    @Autowired
+    protected lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    protected lateinit var mockMvcBuilder: MockMvcBuilder
+}

--- a/src/test/kotlin/com/coffee/MockBeansConfig.kt
+++ b/src/test/kotlin/com/coffee/MockBeansConfig.kt
@@ -1,0 +1,33 @@
+package com.coffee
+
+import com.coffee.api.cafe.application.port.inbound.FindCafe
+import com.coffee.api.cafe.application.port.inbound.FindCafeArea
+import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
+import com.coffee.api.cafe.application.port.inbound.FindRecommendCafe
+import com.coffee.api.cafe.presentation.adapter.`in`.restapi.mapper.FindAllCafesResponseMapper
+import com.coffee.api.cafe.presentation.adapter.out.DiscordClientAdapter
+import io.mockk.mockk
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class MockBeansConfig {
+
+    @Bean
+    fun findCafe(): FindCafe = mockk(relaxed = true)
+
+    @Bean
+    fun findCafeDetails(): FindCafeDetails = mockk(relaxed = true)
+
+    @Bean
+    fun findCafeArea(): FindCafeArea = mockk(relaxed = true)
+
+    @Bean
+    fun findRecommendCafe(): FindRecommendCafe = mockk(relaxed = true)
+
+    @Bean
+    fun discordClientAdapter(): DiscordClientAdapter = mockk(relaxed = true)
+
+    @Bean
+    fun findAllCafeResponseMapper(): FindAllCafesResponseMapper = mockk(relaxed = true)
+}

--- a/src/test/kotlin/com/coffee/api/cafe/domain/CafeTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/domain/CafeTest.kt
@@ -1,0 +1,47 @@
+package com.coffee.api.cafe.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class CafeTest {
+
+    @DisplayName("카페 정보를 받아 카페를 생성한다")
+    @Test
+    fun create() {
+        // given
+        val id = UUID.randomUUID()
+        val reasonForSelection = "최고의 커피와 분위기"
+        val naverMapUrl = "https://naver.com/cafe/bluebottle"
+        val name = "블루보틀"
+        val nearestStation = "강남역"
+        val location = "서울"
+        val price = 5000
+        val previewImages = listOf("img1", "img2")
+        val mainImages = listOf("main1", "main2")
+        val area = CafeArea.CITYHALL_GWANGHWAMUN
+
+        // when
+        val cafe = Cafe(
+            id = id,
+            reasonForSelection = reasonForSelection,
+            naverMapUrl = naverMapUrl,
+            name = name,
+            nearestStation = nearestStation,
+            location = location,
+            price = price,
+            previewImages = previewImages,
+            mainImages = mainImages,
+            area = area
+        )
+
+        // then
+        assertThat(cafe.id).isNotNull()
+        assertThat(cafe.previewImages).hasSize(2)
+        assertThat(cafe)
+            .extracting("location", "price")
+            .contains("서울", 5000)
+    }
+
+}

--- a/src/test/kotlin/com/coffee/api/cafe/domain/CoffeeBeanTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/domain/CoffeeBeanTest.kt
@@ -1,0 +1,85 @@
+package com.coffee.api.cafe.domain
+
+import com.coffee.api.common.domain.UUIDTypeId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CoffeeBeanTest {
+
+    @DisplayName("원두 정보를 받아 원두를 생성한다")
+    @Test
+    fun create() {
+        // given
+        val id = UUID.randomUUID()
+        val description = "골드문트는 독일어로 ‘황금입술’이라고 합니다. 최고급 라인업으로 분류되는 이 커피는 게이샤 품종으로, 풍부한 향과 깔끔한 맛을 특징으로 합니다."
+        val cafe = createCafe()
+        val name = "[골드문트] 콜롬비아 나리뇨 라 레이나 벨렌 게이샤"
+        val engName = "COLOMBIA NARIÑO LA REINA BELEN GEISHA"
+        val flavors = listOf(Flavor.ALMOND, Flavor.FLORAL, Flavor.APRICOT)
+        val countryOfOrigin = mutableListOf(createCountryOfOrigin())
+        val roastingPoint = RoastingPoint.LIGHT
+
+
+        // when
+        val coffeeBean = CoffeeBean(
+            id = id,
+            description = description,
+            cafe = cafe,
+            name = name,
+            engName = engName,
+            flavors = flavors,
+            countryOfOrigin = countryOfOrigin,
+            roastingPoint = roastingPoint
+        )
+
+        // then
+        assertThat(coffeeBean.id).isNotNull()
+        assertThat(coffeeBean)
+            .extracting("name", "roastingPoint")
+            .contains("[골드문트] 콜롬비아 나리뇨 라 레이나 벨렌 게이샤", RoastingPoint.LIGHT)
+        assertThat(coffeeBean.flavors).hasSize(3)
+            .contains(Flavor.ALMOND, Flavor.FLORAL, Flavor.APRICOT)
+    }
+
+    private fun createCountryOfOrigin(): CountryOrigin {
+        val name = "콜롬비아"
+        val flagImageUrl = "https://colombia.xyz"
+
+        val countryOrigin = CountryOrigin(
+                name = name,
+                flagImageUrl = flagImageUrl
+        )
+        return countryOrigin
+    }
+
+    private fun createCafe() : Cafe {
+        val id = UUID.randomUUID()
+        val reasonForSelection = "최고의 커피와 분위기"
+        val naverMapUrl = "https://naver.com/cafe/bluebottle"
+        val name = "블루보틀"
+        val nearestStation = "강남역"
+        val location = "서울"
+        val price = 5000
+        val previewImages = listOf("img1", "img2")
+        val mainImages = listOf("main1", "main2")
+        val area = CafeArea.CITYHALL_GWANGHWAMUN
+
+        val cafe = Cafe(
+                id = id,
+                reasonForSelection = reasonForSelection,
+                naverMapUrl = naverMapUrl,
+                name = name,
+                nearestStation = nearestStation,
+                location = location,
+                price = price,
+                previewImages = previewImages,
+                mainImages = mainImages,
+                area = area
+        )
+
+        return cafe
+    }
+
+}

--- a/src/test/kotlin/com/coffee/api/cafe/domain/CoffeeBeanTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/domain/CoffeeBeanTest.kt
@@ -21,7 +21,6 @@ class CoffeeBeanTest {
         val countryOfOrigin = mutableListOf(createCountryOfOrigin())
         val roastingPoint = RoastingPoint.LIGHT
 
-
         // when
         val coffeeBean = CoffeeBean(
             id = id,

--- a/src/test/kotlin/com/coffee/api/cafe/domain/CountryOriginTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/domain/CountryOriginTest.kt
@@ -1,0 +1,45 @@
+package com.coffee.api.cafe.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class CountryOriginTest {
+
+    @DisplayName("유효한 국가 이름과 국기 이미지 URL로 원두 산지를 생성한다")
+    @Test
+    fun create() {
+        // given
+        val name = "콜롬비아"
+        val flagImageUrl = "www.colombiaflag.com/images/flag"
+
+        // when
+        val countryOrigin = CountryOrigin(
+            name = name,
+            flagImageUrl = flagImageUrl
+        )
+
+        // then
+        assertThat(countryOrigin)
+            .extracting("name", "flagImageUrl")
+            .contains("콜롬비아", "www.colombiaflag.com/images/flag")
+    }
+
+    @DisplayName("국가 이름이 공백이면 원두 산지 생성 시 예외가 발생한다")
+    @Test
+    fun createWithEmptyName() {
+        // given
+        val name = ""
+        val flagImageUrl = "www.colombiaflag.com/images/flag"
+
+        // when // then
+        assertThatThrownBy {
+            CountryOrigin(
+                name = name,
+                flagImageUrl = flagImageUrl
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("국가 이름은 공백일 수 없습니다.")
+    }
+}

--- a/src/test/kotlin/com/coffee/api/cafe/domain/MenuTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/domain/MenuTest.kt
@@ -1,0 +1,5 @@
+package com.coffee.api.cafe.domain
+
+import org.junit.jupiter.api.Assertions.*
+
+class MenuTest

--- a/src/test/kotlin/com/coffee/api/cafe/domain/MenuTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/domain/MenuTest.kt
@@ -1,5 +1,64 @@
 package com.coffee.api.cafe.domain
 
-import org.junit.jupiter.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
 
-class MenuTest
+class MenuTest {
+
+    @DisplayName("메뉴 정보로 메뉴를 생성합니다")
+    @Test
+    fun create() {
+        // given
+        val id = UUID.randomUUID()
+        val name = "소금 커피"
+        val cafe = createCafe()
+        val price = 3000
+        val imageUrl = "www.saltcoffee.co.kr/image"
+        val description = "심심하지 않은 맛이 나는 커피"
+
+        // when
+        val menu = Menu(
+            id = id,
+            name = name,
+            cafe = cafe,
+            price = price,
+            imageUrl = imageUrl,
+            description = description
+        )
+
+        // then
+        assertThat(menu.id).isNotNull()
+        assertThat(menu.name).isEqualTo("소금 커피")
+
+    }
+
+    private fun createCafe() : Cafe {
+        val id = UUID.randomUUID()
+        val reasonForSelection = "최고의 커피와 분위기"
+        val naverMapUrl = "https://naver.com/cafe/bluebottle"
+        val name = "블루보틀"
+        val nearestStation = "강남역"
+        val location = "서울"
+        val price = 5000
+        val previewImages = listOf("img1", "img2")
+        val mainImages = listOf("main1", "main2")
+        val area = CafeArea.CITYHALL_GWANGHWAMUN
+
+        val cafe = Cafe(
+            id = id,
+            reasonForSelection = reasonForSelection,
+            naverMapUrl = naverMapUrl,
+            name = name,
+            nearestStation = nearestStation,
+            location = location,
+            price = price,
+            previewImages = previewImages,
+            mainImages = mainImages,
+            area = area
+        )
+
+        return cafe
+    }
+}

--- a/src/test/kotlin/com/coffee/api/cafe/domain/TagTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/domain/TagTest.kt
@@ -1,0 +1,5 @@
+package com.coffee.api.cafe.domain
+
+import org.junit.jupiter.api.Assertions.*
+
+class TagTest

--- a/src/test/kotlin/com/coffee/api/cafe/domain/TagTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/domain/TagTest.kt
@@ -1,5 +1,28 @@
 package com.coffee.api.cafe.domain
 
-import org.junit.jupiter.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
 
-class TagTest
+class TagTest {
+
+    @DisplayName("태그 정보로 태그를 생성한다")
+    @Test
+    fun create() {
+        // given
+        val id = UUID.randomUUID()
+        val name = "brand"
+        val imageUrl = "www.imageUrl.xzy/image"
+        val priority = 1.1f
+
+        // when
+        val tag = Tag.create(id, name, imageUrl, priority)
+
+        // then
+        assertThat(tag.id).isNotNull()
+        assertThat(tag)
+            .extracting("name", "imageUrl", "priority")
+            .contains("brand", "www.imageUrl.xzy/image", 1.1f)
+    }
+}

--- a/src/test/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeControllerTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeControllerTest.kt
@@ -94,6 +94,7 @@ class CafeControllerTest : ControllerTestSupport() {
 
         val result = FindCafeDetails.Result(dummyCafeDetails)
 
+        // stubbing
         every { findCafeDetails.invoke(any()) } returns result
 
         // when // then

--- a/src/test/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeControllerTest.kt
+++ b/src/test/kotlin/com/coffee/api/cafe/presentation/adapter/in/restapi/CafeControllerTest.kt
@@ -1,0 +1,112 @@
+package com.coffee.api.cafe.presentation.adapter.`in`.restapi
+
+import com.coffee.ControllerTestSupport
+import com.coffee.api.cafe.application.model.CafeDetails
+import com.coffee.api.cafe.application.port.inbound.FindCafe
+import com.coffee.api.cafe.application.port.inbound.FindCafeDetails
+import com.coffee.api.cafe.domain.Cafe
+import com.coffee.api.cafe.domain.CafeArea
+import com.coffee.api.cafe.domain.CoffeeBean
+import com.coffee.api.cafe.domain.RoastingPoint
+import io.mockk.every
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+class CafeControllerTest : ControllerTestSupport() {
+
+    @Autowired
+    lateinit var findCafe: FindCafe
+
+    @Autowired
+    lateinit var findCafeDetails: FindCafeDetails
+
+    @DisplayName("카페 목록을 조회한다.")
+    @Test
+    fun findAllCafes() {
+        // given
+        val result = FindCafe.Result(
+            emptyList(),
+            false
+        )
+
+        // stubbing
+        every { findCafe.invoke(any()) } returns result
+
+        // when // then
+        mockMvc.perform(
+            get("/api/v1/cafes")
+                .param("lastCafeId", "123e4567-e89b-12d3-a456-556642440000")
+                .param("area", "HONGDAE")
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result").value("SUCCESS"))
+            .andExpect(jsonPath("$.data.hasNext").isBoolean())
+            .andExpect(jsonPath("$.data.cafes").isArray())
+    }
+
+    @DisplayName("카페 상세 정보를 조회한다.")
+    @Test
+    fun getCafeDetails() {
+        // given
+        val now = LocalDateTime.now()
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+        val dummyCafe = Cafe.create(
+            id = UUID.fromString("123e4567-e89b-12d3-a456-556642440000"),
+            reasonForSelection = "스몰토크를 좋아하는 사장님은 지역사회에 따뜻한 온기를 불어넣습니다. 스피드스터 커피머신과 이쪼 발키리를 사용하며. 게이샤의 맛을 알리는데 일조합니다.",
+            naverMapUrl = "http://naver.com",
+            name = "텐스퀘어 남산",
+            nearestStation = "Test Station",
+            location = "Test Location",
+            price = 1000,
+            previewImages = listOf("preview1.jpg", "preview2.jpg"),
+            mainImages = listOf("main1.jpg"),
+            area = CafeArea.CHEONGYE_JONGRO
+        )
+
+        val dummyCoffeeBean = CoffeeBean.create(
+            id = UUID.fromString("223e4567-e89b-12d3-a456-556642440000"),
+            description = "Rich and smooth coffee bean",
+            cafe = dummyCafe,
+            name = "Test CoffeeBean",
+            engName = "Test CoffeeBean",
+            flavors = emptyList(),
+            countryOfOrigin = mutableListOf(),
+            roastingPoint = RoastingPoint.MEDIUM
+        )
+
+        val dummyCafeDetails = CafeDetails(
+            cafe = dummyCafe,
+            coffeeBean = dummyCoffeeBean,
+            menu = emptyList(),  // 메뉴 데이터가 있다면 추가
+            tag = emptyList(),   // 태그 데이터가 있다면 추가
+            updatedAt = now
+        )
+
+        val result = FindCafeDetails.Result(dummyCafeDetails)
+
+        every { findCafeDetails.invoke(any()) } returns result
+
+        // when // then
+        mockMvc.perform(
+            get("/api/v1/cafes/details/{cafeId}", "123e4567-e89b-12d3-a456-556642440000")
+                .param("cafeId", "123e4567-e89b-12d3-a456-556642440000")
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result").value("SUCCESS"))
+            .andExpect(jsonPath("$.data.cafe.name").value("텐스퀘어 남산"))
+            .andExpect(jsonPath("$.data.coffeeBean.name").value("Test CoffeeBean"))
+            .andExpect(jsonPath("$.data.updatedAt").value(now.format(formatter)))
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
close #61 

## 주요 변경 사항

컨트롤러 계층을 위한 부분적인 코드 리팩토링이 있었습니다.
우선, 컨트롤러를 가능한 단순하게 작성하려고 했습니다. 현재처럼 dto 변환을 컨트롤러에서 하면 코드의 유지보수성과
협업자의 코드 가독성이 떨어지기 때문에 mapper 계층을 도입하여 코드의 가시성을 높이려고 했습니다.
그리고 컨트롤러단을 위한 WebMvcTest 컨트롤러 통합테스트를 작성했습니다. 
Kotlin Test는 자바와 달리 MockK가 호환성이 높은데 MockK에 컨트롤러 통합테스트를 위한 자바 테스트의 Mockito의 MockBean 애노테이션을 지원하지 않는 것으로 확인되어 테스트를 위한 config를 작성하였습니다.

## 기타
작성중

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 도큐먼트 생성 플러그인과 관련 의존성 설정이 추가되어 빌드 프로세스가 개선되었습니다.
	- API 문서에 카페 조회 관련 새로운 섹션이 도입되어 문서화가 강화되었습니다.
	- 카페 REST API 문서를 위한 새로운 AsciiDoc 파일이 생성되었습니다.
	- 카페 목록 및 세부 정보를 조회하는 새로운 API 테스트가 추가되었습니다.
- **리팩토링**
	- 응답 데이터 매핑 로직이 매퍼 객체로 분리되어 코드 유지보수성이 향상되었습니다.
	- 응답 구조가 조정되어 데이터 전달 방식이 명확해졌습니다.
- **테스트**
	- 웹 레이어 테스트 지원을 위한 새로운 테스트 클래스와 구성 설정이 추가되었습니다.
	- 카페 관련 API의 동작을 검증하는 새로운 테스트 클래스가 추가되었습니다.
	- 카페 및 커피빈 객체 생성을 검증하는 테스트 클래스가 추가되었습니다.
	- 국가 원산지 및 메뉴 관련 테스트 클래스가 추가되었습니다.
	- 태그 관련 테스트 클래스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->